### PR TITLE
fix: guard docker-entrypoint sed against empty env vars

### DIFF
--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -1,15 +1,34 @@
 #!/bin/sh
+set -e
 
-# Replace environment variables in the built JavaScript files
-echo "Replacing environment variables..."
-for file in /usr/share/nginx/html/static/js/*.js; do
-  echo "Processing $file..."
-  sed -i \
-    -e "s|http://localhost/api|${REACT_APP_API_URL}|g" \
-    -e "s|ws://localhost|${REACT_APP_WEBSOCKET_URL}|g" \
-    "$file"
-done
+# Runtime environment variable replacement in built JS bundles.
+#
+# The React build bakes in default API URLs (e.g. http://localhost/api).
+# When deploying to a different host (Kubernetes, remote server), pass
+# REACT_APP_API_URL and REACT_APP_WEBSOCKET_URL as runtime env vars
+# to override those defaults at container startup.
+#
+# IMPORTANT: If the env vars are NOT set, we skip replacement entirely
+# so the build-time defaults remain intact (required for docker-compose
+# where nginx proxies /api to the backend).
+
+if [ -n "${REACT_APP_API_URL}" ] || [ -n "${REACT_APP_WEBSOCKET_URL}" ]; then
+  echo "Runtime env override detected — replacing API URLs in JS bundles..."
+  for file in /usr/share/nginx/html/static/js/*.js; do
+    if [ -f "$file" ]; then
+      echo "  Processing $file..."
+      if [ -n "${REACT_APP_API_URL}" ]; then
+        sed -i "s|http://localhost/api|${REACT_APP_API_URL}|g" "$file"
+      fi
+      if [ -n "${REACT_APP_WEBSOCKET_URL}" ]; then
+        sed -i "s|ws://localhost|${REACT_APP_WEBSOCKET_URL}|g" "$file"
+      fi
+    fi
+  done
+  echo "URL replacement complete."
+else
+  echo "No runtime API URL overrides set — using build-time defaults."
+fi
 
 echo "Starting Nginx..."
-# Start nginx
 exec "$@"


### PR DESCRIPTION
## Problem

Commit `f899d10` added `docker-entrypoint.sh` as the container ENTRYPOINT to support runtime API URL replacement. However, the script **unconditionally** runs `sed` to replace the build-time URL defaults (`http://localhost/api`, `ws://localhost`) with the values of `REACT_APP_API_URL` and `REACT_APP_WEBSOCKET_URL`.

When running via `docker-compose`, the client service does **not** pass these as runtime env vars (they are only build `ARG`s). So at container startup:
- `REACT_APP_API_URL` → **empty string**
- `REACT_APP_WEBSOCKET_URL` → **empty string**

The `sed` replaces all API URLs in the JS bundle with empty strings. Every `fetch()` call then hits `""` → resolves to the nginx root → returns `index.html` (HTML) instead of JSON → the app crashes with `TypeError: undefined is not an object (evaluating 'd.map')` on every page that makes API calls (Settings, Dashboard, etc.).

## Root Cause

```sh
# OLD (always runs, even when vars are empty):
sed -i -e "s|http://localhost/api|${REACT_APP_API_URL}|g" "$file"
#                                  ^^^^^^^^^^^^^^^^^^^^^^^^
#                                  Empty → replaces URLs with nothing
```

## Fix

Only run the `sed` replacement when the env vars are **actually set** (non-empty). When not set, the build-time defaults remain intact and work correctly with the existing `nginx.conf` `proxy_pass` to `server:5001`.

```sh
# NEW (guarded):
if [ -n "${REACT_APP_API_URL}" ]; then
  sed -i "s|http://localhost/api|${REACT_APP_API_URL}|g" "$file"
fi
```

Also added:
- `set -e` for fail-fast behavior
- File existence check (`[ -f "$file" ]`) to avoid errors on empty glob
- Clear startup logging for debugging
- Proper newline at end of file

## Testing

**Docker Compose (default — no runtime env vars):**
```bash
docker compose up --build -d
# Settings page loads ✅
# API calls return JSON ✅
# No sed replacement runs (build defaults preserved)
```

**Kubernetes / custom deployment (with runtime env vars):**
```bash
docker run -e REACT_APP_API_URL=https://myhost.com/api \
           -e REACT_APP_WEBSOCKET_URL=wss://myhost.com \
           -p 8080:80 runwatch-client:fix
# URLs replaced at startup ✅
# API calls route to custom host ✅
```

Fixes regression from f899d10.