### PR TITLE
✨ Add Self-Hosted Runners View

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The application is structured as follows:
    - Create a GitHub App in your organization's settings
    - Define the below **Repository permissions** for the App:
      - `Read` access to **Actions**
+     - `Read` access to **Administration** _(required for repo-level self-hosted runners)_
      - `Read` access to **Metadata**
      - `Read and write` access to **Workflows** _(reserved for future use)_
    - Define the below **Organization permissions** for the App:
@@ -125,7 +126,11 @@ The application is structured as follows:
    - Place the private key file in your project directory
    - Update the `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_PATH` in your `.env` file
 
-   > **Upgrading?** If you already have a GitHub App configured for RunWatch, go to your App's settings → Permissions & events → Organization permissions → add **Self-hosted runners: Read**. Then visit each installation and approve the new permission request.
+   > **Upgrading?** If you already have a GitHub App configured for RunWatch, go to your App's settings → Permissions & events:
+   > - **Organization permissions** → add **Self-hosted runners: Read**
+   > - **Repository permissions** → add **Administration: Read** _(needed for repo-level runners)_
+   >
+   > Then visit each installation and approve the new permission request.
 
 ### Backend Setup
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ RunWatch is a real-time monitoring application for GitHub Actions workflows. It 
 - 📊 Dashboard displaying current and historical workflow runs
 - 🔍 Detailed view of individual workflow runs and jobs
 - 📈 Statistics and analytics on workflow performance
+- 🤖 **Self-hosted runners monitoring** — view runner status, OS, labels, runner groups across all installations
 - 🔔 WebSocket-based real-time updates
 - 🔒 Security hardened: rate limiting, CORS allowlist, helmet headers, MongoDB auth, admin token protection
 
@@ -109,9 +110,13 @@ The application is structured as follows:
 
 5. Set up your GitHub App:
    - Create a GitHub App in your organization's settings
-   - Define the below permissions for the App:
-     - `Read` access to actions, metadata, and organization administration
-     - `Read and write` access to workflows
+   - Define the below **Repository permissions** for the App:
+     - `Read` access to **Actions**
+     - `Read` access to **Metadata**
+     - `Read and write` access to **Workflows** _(reserved for future use)_
+   - Define the below **Organization permissions** for the App:
+     - `Read` access to **Administration** _(required for org-level data)_
+     - `Read` access to **Self-hosted runners** _(required for the Runners view)_
    - Subscribe to the below events:
      - `Workflow Job`
      - `Workflow Run`
@@ -119,6 +124,8 @@ The application is structured as follows:
    - Generate and download the private key
    - Place the private key file in your project directory
    - Update the `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_PATH` in your `.env` file
+
+   > **Upgrading?** If you already have a GitHub App configured for RunWatch, go to your App's settings → Permissions & events → Organization permissions → add **Self-hosted runners: Read**. Then visit each installation and approve the new permission request.
 
 ### Backend Setup
 
@@ -315,6 +322,7 @@ The Docker setup includes:
 - Authentication and multi-user support
 - More advanced filtering and search capabilities
 - Custom notifications for workflow failures
+- ARC / Kubernetes Scale Set integration for runner monitoring
 - Integration with other CI/CD platforms
 
 ## License

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm install --legacy-peer-deps
+# Install dependencies strictly from lockfile
+RUN npm ci --legacy-peer-deps
 
 # Copy source
 COPY . .

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import RepositoryStats from './features/stats/RepositoryStats';
 import WorkflowHistory from './features/workflows/WorkflowHistory';
 import RepositoryView from './features/repository/RepositoryView';
 import Settings from './features/settings/Settings';
+import RunnersView from './features/runners/RunnersView';
 import { AdminTokenProvider } from './common/context/AdminTokenContext';
 import './App.css';
 
@@ -20,6 +21,7 @@ function App() {
             <Route path="/workflow/:id" element={<WorkflowDetails />} />
             <Route path="/workflow-history/:repoName/:workflowName" element={<WorkflowHistory />} />
             <Route path="/repository/:repoName" element={<RepositoryView />} />
+            <Route path="/runners" element={<RunnersView />} />
             <Route path="/stats" element={<RepositoryStats />} />
             <Route path="/settings" element={<Settings />} />
           </Routes>

--- a/client/src/api/apiService.js
+++ b/client/src/api/apiService.js
@@ -257,6 +257,17 @@ const apiService = {
     }
   },
 
+  // Check if the GitHub App has the Self-hosted runners (Read) permission
+  getRunnersStatus: async () => {
+    try {
+      const response = await api.get(`${API_URL}/runners/status`);
+      return response.data.data || { available: false, reason: 'Unknown' };
+    } catch (error) {
+      console.error('Error fetching runners status:', error);
+      return { available: false, reason: 'Backend unreachable' };
+    }
+  },
+
   // Get all self-hosted runners with optional filters
   getRunners: async (filters = {}) => {
     try {

--- a/client/src/api/apiService.js
+++ b/client/src/api/apiService.js
@@ -289,6 +289,17 @@ const apiService = {
       throw error;
     }
   },
+
+  // Force invalidate the runner cache on the server
+  invalidateRunnerCache: async () => {
+    try {
+      const response = await api.post(`${API_URL}/runners/cache/invalidate`);
+      return response.data.data;
+    } catch (error) {
+      console.error('Error invalidating runner cache:', error);
+      throw error;
+    }
+  },
 };
 
 export default apiService;

--- a/client/src/api/apiService.js
+++ b/client/src/api/apiService.js
@@ -255,7 +255,29 @@ const apiService = {
       console.error('Error fetching database status:', error);
       throw error;
     }
-  }
+  },
+
+  // Get all self-hosted runners with optional filters
+  getRunners: async (filters = {}) => {
+    try {
+      const response = await api.get(`${API_URL}/runners`, { params: filters });
+      return response.data.data || { runners: [], summary: {} };
+    } catch (error) {
+      console.error('Error fetching runners:', error);
+      throw error;
+    }
+  },
+
+  // Get a specific runner by ID
+  getRunnerById: async (id) => {
+    try {
+      const response = await api.get(`${API_URL}/runners/${encodeURIComponent(String(id))}`);
+      return response.data.data;
+    } catch (error) {
+      console.error('Error fetching runner:', sanitizeLog(id), error);
+      throw error;
+    }
+  },
 };
 
 export default apiService;

--- a/client/src/common/components/Layout.jsx
+++ b/client/src/common/components/Layout.jsx
@@ -1,14 +1,25 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
+import apiService from '../../api/apiService';
 
-const navItems = [
+const staticNavItems = [
   { text: 'Workflows', icon: 'dashboard', path: '/' },
-  { text: 'Runners', icon: 'precision_manufacturing', path: '/runners' },
   { text: 'Statistics', icon: 'analytics', path: '/stats' },
   { text: 'Settings', icon: 'settings', path: '/settings' },
 ];
 
+const RUNNERS_TOOLTIP =
+  'Self-hosted runners monitoring requires additional GitHub App permissions. Contact your admin to enable the Self-hosted runners (Read) permission.';
+
 const Layout = ({ children }) => {
+  const [runnersAvailable, setRunnersAvailable] = useState(false);
+
+  useEffect(() => {
+    apiService.getRunnersStatus().then((status) => {
+      setRunnersAvailable(status.available === true);
+    });
+  }, []);
+
   return (
     <div className="bg-surface text-on-surface antialiased overflow-hidden">
       {/* Sidebar */}
@@ -18,11 +29,54 @@ const Layout = ({ children }) => {
         </div>
 
         <nav className="flex-1 space-y-1">
-          {navItems.map(({ text, icon, path }) => (
+          {/* Static nav items (Workflows first, then others after Runners) */}
+          <NavLink
+            to="/"
+            end
+            className={({ isActive }) =>
+              `flex items-center gap-3 px-3 py-2 transition-colors duration-200 hover:bg-[#1c2026] ${
+                isActive
+                  ? 'text-[#a2c9ff] font-medium border-l-2 border-[#a2c9ff]'
+                  : 'text-[#dfe2eb]/60 hover:text-[#dfe2eb]'
+              }`
+            }
+          >
+            <span className="material-symbols-outlined">dashboard</span>
+            Workflows
+          </NavLink>
+
+          {/* Runners nav item — conditional on permission */}
+          {runnersAvailable ? (
+            <NavLink
+              to="/runners"
+              className={({ isActive }) =>
+                `flex items-center gap-3 px-3 py-2 transition-colors duration-200 hover:bg-[#1c2026] ${
+                  isActive
+                    ? 'text-[#a2c9ff] font-medium border-l-2 border-[#a2c9ff]'
+                    : 'text-[#dfe2eb]/60 hover:text-[#dfe2eb]'
+                }`
+              }
+            >
+              <span className="material-symbols-outlined">precision_manufacturing</span>
+              Runners
+            </NavLink>
+          ) : (
+            <div className="relative group">
+              <div className="flex items-center gap-3 px-3 py-2 text-[#dfe2eb]/25 cursor-not-allowed select-none">
+                <span className="material-symbols-outlined">precision_manufacturing</span>
+                Runners
+              </div>
+              <div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 z-50 hidden group-hover:block w-64 bg-[#1c2026] border border-[#dfe2eb]/10 rounded-lg px-3 py-2 text-xs text-[#dfe2eb]/60 shadow-xl pointer-events-none">
+                {RUNNERS_TOOLTIP}
+              </div>
+            </div>
+          )}
+
+          {/* Statistics and Settings */}
+          {staticNavItems.slice(1).map(({ text, icon, path }) => (
             <NavLink
               key={path}
               to={path}
-              end={path === '/'}
               className={({ isActive }) =>
                 `flex items-center gap-3 px-3 py-2 transition-colors duration-200 hover:bg-[#1c2026] ${
                   isActive

--- a/client/src/common/components/Layout.jsx
+++ b/client/src/common/components/Layout.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 const navItems = [
-  { text: 'Dashboard', icon: 'dashboard', path: '/' },
+  { text: 'Workflows', icon: 'dashboard', path: '/' },
+  { text: 'Runners', icon: 'precision_manufacturing', path: '/runners' },
   { text: 'Statistics', icon: 'analytics', path: '/stats' },
   { text: 'Settings', icon: 'settings', path: '/settings' },
 ];

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -278,7 +278,8 @@ const RunnersView = () => {
   const [statusFilter, setStatusFilter] = useState('all');
   const [labelFilter, setLabelFilter] = useState('');
   const [runnersAvailable, setRunnersAvailable] = useState(null); // null = checking
-  const [lastUpdated, setLastUpdated] = useState(null);
+  const [cacheInfo, setCacheInfo] = useState(null);
+  const [refreshing, setRefreshing] = useState(false);
   const intervalRef = useRef(null);
 
   const fetchRunners = async (showLoading = false) => {
@@ -290,14 +291,25 @@ const RunnersView = () => {
       const data = await apiService.getRunners(filters);
       setRunners(data.runners ?? []);
       setSummary(data.summary ?? { total: 0, online: 0, busy: 0, offline: 0 });
+      setCacheInfo(data.cache ?? null);
       setError(null);
-      setLastUpdated(new Date());
     } catch (err) {
       setError('Failed to fetch runners. Please try again.');
       console.error(err);
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
+  };
+
+  const handleForceRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await apiService.invalidateRunnerCache();
+    } catch (err) {
+      console.error('Failed to invalidate cache:', err);
+    }
+    await fetchRunners(false);
   };
 
   // Permission check on mount
@@ -482,15 +494,29 @@ const RunnersView = () => {
             )}
           </div>
 
-          {/* Manual refresh */}
-          <button
-            onClick={() => { fetchRunners(true); }}
-            title="Refresh"
-            className="p-1.5 text-on-surface-variant hover:text-primary material-symbols-outlined transition-colors leading-none"
-            style={{ fontSize: '18px' }}
-          >
-            refresh
-          </button>
+          {/* Cache info + refresh */}
+          <div className="flex items-center gap-2">
+            {cacheInfo && cacheInfo.cachedAt && (
+              <span className="text-[10px] text-on-surface-variant/40" title={`Cache TTL: ${Math.round(cacheInfo.ttlMs / 1000)}s`}>
+                {cacheInfo.ageMs != null
+                  ? `Cached ${Math.round(cacheInfo.ageMs / 1000)}s ago`
+                  : 'Fresh'}
+              </span>
+            )}
+            <button
+              onClick={handleForceRefresh}
+              disabled={refreshing}
+              title="Force refresh (bypass cache)"
+              className={`p-1.5 material-symbols-outlined transition-colors leading-none ${
+                refreshing
+                  ? 'text-primary animate-spin'
+                  : 'text-on-surface-variant hover:text-primary'
+              }`}
+              style={{ fontSize: '18px' }}
+            >
+              refresh
+            </button>
+          </div>
         </div>
       </div>
 

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import apiService from '../../api/apiService';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ const osIcon = (os) => {
 
 // ─── RunnerCard ────────────────────────────────────────────────────────────────
 
-const RunnerCard = ({ runner }) => {
+const RunnerCard = ({ runner, onLabelClick }) => {
   const meta = statusMeta(runner.status);
 
   return (
@@ -87,12 +87,14 @@ const RunnerCard = ({ runner }) => {
       {runner.labels.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {runner.labels.map((label) => (
-            <span
+            <button
               key={label}
-              className="px-2 py-0.5 rounded-full bg-primary/10 border border-primary/20 text-[10px] font-medium text-primary/80"
+              onClick={() => onLabelClick && onLabelClick(label)}
+              className="px-2 py-0.5 rounded-full bg-primary/10 border border-primary/20 text-[10px] font-medium text-primary/80 hover:bg-primary/20 hover:text-primary transition-colors cursor-pointer"
+              title={`Filter by "${label}"`}
             >
               {label}
-            </span>
+            </button>
           ))}
         </div>
       )}
@@ -102,7 +104,7 @@ const RunnerCard = ({ runner }) => {
 
 // ─── RunnerGroup ──────────────────────────────────────────────────────────────
 
-const RunnerGroup = ({ groupName, runners }) => {
+const RunnerGroup = ({ groupName, runners, onLabelClick }) => {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
@@ -128,7 +130,7 @@ const RunnerGroup = ({ groupName, runners }) => {
       {!collapsed && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
           {runners.map((runner) => (
-            <RunnerCard key={runner.id} runner={runner} />
+            <RunnerCard key={runner.id} runner={runner} onLabelClick={onLabelClick} />
           ))}
         </div>
       )}
@@ -138,7 +140,7 @@ const RunnerGroup = ({ groupName, runners }) => {
 
 // ─── OrgSection ───────────────────────────────────────────────────────────────
 
-const OrgSection = ({ orgName, runners }) => {
+const OrgSection = ({ orgName, runners, onLabelClick }) => {
   const [collapsed, setCollapsed] = useState(false);
 
   // Group runners by runner group within this org
@@ -212,6 +214,7 @@ const OrgSection = ({ orgName, runners }) => {
               key={groupName || '__default__'}
               groupName={groupName}
               runners={groupRunners}
+              onLabelClick={onLabelClick}
             />
           ))}
         </div>
@@ -237,7 +240,6 @@ const RunnersView = () => {
     try {
       const filters = {};
       if (statusFilter !== 'all') filters.status = statusFilter;
-      if (labelFilter) filters.label = labelFilter;
 
       const data = await apiService.getRunners(filters);
       setRunners(data.runners ?? []);
@@ -265,18 +267,35 @@ const RunnersView = () => {
     fetchRunners();
     intervalRef.current = setInterval(fetchRunners, 30000);
     return () => clearInterval(intervalRef.current);
-  }, [statusFilter, labelFilter, runnersAvailable]);
+  }, [statusFilter, runnersAvailable]);
 
   // Client-side name search filter
   const filteredRunners = useMemo(() => {
-    if (!searchQuery) return runners;
-    const q = searchQuery.toLowerCase();
-    return runners.filter(
-      (r) =>
-        r.name.toLowerCase().includes(q) ||
-        r.owner.toLowerCase().includes(q) ||
-        (r.repo && r.repo.toLowerCase().includes(q))
-    );
+    let result = runners;
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.owner.toLowerCase().includes(q) ||
+          (r.repo && r.repo.toLowerCase().includes(q))
+      );
+    }
+
+    if (labelFilter) {
+      const lf = labelFilter.toLowerCase();
+      result = result.filter((r) =>
+        r.labels.some((l) => l.toLowerCase().includes(lf))
+      );
+    }
+
+    return result;
+  }, [runners, searchQuery, labelFilter]);
+
+  const handleLabelClick = useCallback((label) => {
+    setLabelFilter(label);
+  }, []);
   }, [runners, searchQuery]);
 
   // Group by org
@@ -405,8 +424,17 @@ const RunnersView = () => {
               placeholder="Filter by label..."
               value={labelFilter}
               onChange={(e) => setLabelFilter(e.target.value)}
-              className="bg-surface-container-highest rounded-lg px-3 py-1.5 w-40 text-xs text-on-surface-variant border-none outline-none focus:ring-1 focus:ring-primary/40"
+              className="bg-surface-container-highest rounded-lg px-3 py-1.5 w-40 text-xs text-on-surface border-none outline-none focus:ring-1 focus:ring-primary/40"
             />
+            {labelFilter && (
+              <button
+                onClick={() => setLabelFilter('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-outline hover:text-on-surface material-symbols-outlined leading-none"
+                style={{ fontSize: '14px' }}
+              >
+                close
+              </button>
+            )}
           </div>
 
           {/* Manual refresh */}
@@ -490,6 +518,7 @@ const RunnersView = () => {
               key={orgName}
               orgName={orgName}
               runners={orgRunners}
+              onLabelClick={handleLabelClick}
             />
           ))
         )}

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -51,10 +51,25 @@ const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
         <span className="font-semibold text-xs text-on-surface truncate" title={runner.name}>
           {runner.name}
         </span>
-        {runner.scope === 'repo' && (
-          <span className="flex-shrink-0 flex items-center gap-1 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[9px] font-medium text-tertiary/80">
+        {runner.scope === 'repo' && runner.repo && (
+          <span className="flex-shrink-0 flex items-center gap-1.5 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[9px] font-medium text-tertiary/80">
             <span className="material-symbols-outlined leading-none" style={{ fontSize: '10px' }}>source</span>
-            {runner.repo}
+            <a
+              href={`/repository/${runner.owner}/${runner.repo}`}
+              className="hover:text-tertiary hover:underline transition-colors"
+              title="View in RunWatch"
+            >
+              {runner.repo}
+            </a>
+            <a
+              href={`https://github.com/${runner.owner}/${runner.repo}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-tertiary transition-colors"
+              title="View on GitHub"
+            >
+              <span className="material-symbols-outlined leading-none" style={{ fontSize: '10px' }}>open_in_new</span>
+            </a>
           </span>
         )}
       </div>

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -136,6 +136,90 @@ const RunnerGroup = ({ groupName, runners }) => {
   );
 };
 
+// ─── OrgSection ───────────────────────────────────────────────────────────────
+
+const OrgSection = ({ orgName, runners }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Group runners by runner group within this org
+  const groupedByGroup = useMemo(() => {
+    const groups = {};
+    for (const runner of runners) {
+      const key = runner.runnerGroup || '';
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(runner);
+    }
+    return groups;
+  }, [runners]);
+
+  const groupEntries = Object.entries(groupedByGroup).sort(([a], [b]) => a.localeCompare(b));
+
+  // Org-level stats
+  const orgStats = useMemo(() => ({
+    total: runners.length,
+    idle: runners.filter((r) => r.status === 'idle').length,
+    busy: runners.filter((r) => r.status === 'busy').length,
+    offline: runners.filter((r) => r.status === 'offline').length,
+  }), [runners]);
+
+  return (
+    <div className="mb-8">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-3 mb-4 group w-full text-left"
+      >
+        <span
+          className={`material-symbols-outlined text-on-surface-variant transition-transform ${
+            collapsed ? '-rotate-90' : ''
+          }`}
+          style={{ fontSize: '18px' }}
+        >
+          expand_more
+        </span>
+        <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '18px' }}>
+          corporate_fare
+        </span>
+        <span className="text-sm font-bold text-on-surface group-hover:text-primary transition-colors">
+          {orgName}
+        </span>
+        <div className="flex items-center gap-2 ml-2">
+          <span className="text-[10px] font-semibold text-on-surface-variant/60">{orgStats.total} runners</span>
+          {orgStats.idle > 0 && (
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-secondary" />
+              <span className="text-[10px] font-semibold text-secondary">{orgStats.idle}</span>
+            </span>
+          )}
+          {orgStats.busy > 0 && (
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-primary" />
+              <span className="text-[10px] font-semibold text-primary">{orgStats.busy}</span>
+            </span>
+          )}
+          {orgStats.offline > 0 && (
+            <span className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-error" />
+              <span className="text-[10px] font-semibold text-error">{orgStats.offline}</span>
+            </span>
+          )}
+        </div>
+      </button>
+
+      {!collapsed && (
+        <div className="ml-6 border-l border-outline-variant/10 pl-4">
+          {groupEntries.map(([groupName, groupRunners]) => (
+            <RunnerGroup
+              key={groupName || '__default__'}
+              groupName={groupName}
+              runners={groupRunners}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // ─── RunnersView ──────────────────────────────────────────────────────────────
 
 const RunnersView = () => {
@@ -195,18 +279,18 @@ const RunnersView = () => {
     );
   }, [runners, searchQuery]);
 
-  // Group by runner group name
-  const groupedByGroup = useMemo(() => {
-    const groups = {};
+  // Group by org
+  const groupedByOrg = useMemo(() => {
+    const orgs = {};
     for (const runner of filteredRunners) {
-      const key = runner.runnerGroup || '';
-      if (!groups[key]) groups[key] = [];
-      groups[key].push(runner);
+      const key = runner.owner || 'Unknown';
+      if (!orgs[key]) orgs[key] = [];
+      orgs[key].push(runner);
     }
-    return groups;
+    return orgs;
   }, [filteredRunners]);
 
-  const groupEntries = Object.entries(groupedByGroup).sort(([a], [b]) => a.localeCompare(b));
+  const orgEntries = Object.entries(groupedByOrg).sort(([a], [b]) => a.localeCompare(b));
 
   // ─── Render ───────────────────────────────────────────────────────────────────
 
@@ -384,7 +468,7 @@ const RunnersView = () => {
         </div>
       </div>
 
-      {/* Runner groups */}
+      {/* Runners grouped by org */}
       <div className="px-6">
         {filteredRunners.length === 0 ? (
           <div className="text-center py-16 bg-primary/5 border border-primary/10 rounded-xl">
@@ -401,11 +485,11 @@ const RunnersView = () => {
             </p>
           </div>
         ) : (
-          groupEntries.map(([groupName, groupRunners]) => (
-            <RunnerGroup
-              key={groupName || '__default__'}
-              groupName={groupName}
-              runners={groupRunners}
+          orgEntries.map(([orgName, orgRunners]) => (
+            <OrgSection
+              key={orgName}
+              orgName={orgName}
+              runners={orgRunners}
             />
           ))
         )}

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -83,6 +83,50 @@ const RunnerCard = ({ runner, onLabelClick }) => {
         </div>
       )}
 
+      {/* Active job (when busy) */}
+      {runner.status === 'busy' && runner.activeJob && (
+        <div className="flex flex-col gap-1.5 bg-primary/5 border border-primary/10 rounded-lg px-3 py-2">
+          <div className="flex items-center gap-1.5 text-[11px] text-primary/80">
+            <span
+              className="material-symbols-outlined leading-none"
+              style={{ fontSize: '13px' }}
+            >
+              play_circle
+            </span>
+            <span className="font-semibold truncate">{runner.activeJob.workflowName || 'Workflow'}</span>
+            {runner.activeJob.jobName && (
+              <span className="text-primary/50 truncate">/ {runner.activeJob.jobName}</span>
+            )}
+          </div>
+          {runner.activeJob.repository && (
+            <div className="text-[10px] text-primary/50 truncate ml-[21px]">{runner.activeJob.repository}</div>
+          )}
+          <div className="flex items-center gap-2 ml-[21px]">
+            {runner.activeJob.workflowRunId && (
+              <a
+                href={`/workflow/${runner.activeJob.workflowRunId}`}
+                className="text-[10px] font-medium text-primary hover:text-primary/80 hover:underline transition-colors"
+                title="View in RunWatch"
+              >
+                RunWatch →
+              </a>
+            )}
+            {runner.activeJob.workflowRunUrl && (
+              <a
+                href={runner.activeJob.workflowRunUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-medium text-primary/60 hover:text-primary/80 hover:underline transition-colors flex items-center gap-0.5"
+                title="View on GitHub"
+              >
+                GitHub
+                <span className="material-symbols-outlined" style={{ fontSize: '10px' }}>open_in_new</span>
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Labels */}
       {runner.labels.length > 0 && (
         <div className="flex flex-wrap gap-1">

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -1,0 +1,371 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import apiService from '../../api/apiService';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const STATUS_OPTIONS = [
+  { label: 'All Status', value: 'all' },
+  { label: 'Idle', value: 'idle' },
+  { label: 'Busy', value: 'busy' },
+  { label: 'Offline', value: 'offline' },
+];
+
+const statusMeta = (status) => {
+  switch (status) {
+    case 'idle':
+      return { dot: 'bg-secondary', text: 'text-secondary', label: 'Idle' };
+    case 'busy':
+      return { dot: 'bg-primary animate-pulse', text: 'text-primary', label: 'Busy' };
+    case 'offline':
+      return { dot: 'bg-error', text: 'text-error', label: 'Offline' };
+    default:
+      return { dot: 'bg-outline-variant', text: 'text-outline', label: status };
+  }
+};
+
+const osIcon = (os) => {
+  if (!os) return 'computer';
+  const lower = os.toLowerCase();
+  if (lower.includes('win')) return 'window';
+  if (lower.includes('mac') || lower.includes('darwin')) return 'laptop_mac';
+  return 'terminal';
+};
+
+// ─── RunnerCard ────────────────────────────────────────────────────────────────
+
+const RunnerCard = ({ runner }) => {
+  const meta = statusMeta(runner.status);
+
+  return (
+    <div className="bg-surface-container rounded-xl border border-outline-variant/10 p-4 flex flex-col gap-3 hover:bg-surface-container-high transition-all">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="material-symbols-outlined text-on-surface-variant flex-shrink-0"
+            style={{ fontSize: '18px' }}
+          >
+            {osIcon(runner.os)}
+          </span>
+          <span className="font-semibold text-sm text-on-surface truncate" title={runner.name}>
+            {runner.name}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <span className={`w-2 h-2 rounded-full ${meta.dot}`} />
+          <span className={`text-xs font-semibold ${meta.text}`}>{meta.label}</span>
+        </div>
+      </div>
+
+      {/* Scope */}
+      <div className="flex items-center gap-1.5 text-[11px] text-outline">
+        <span
+          className="material-symbols-outlined leading-none"
+          style={{ fontSize: '13px' }}
+        >
+          {runner.scope === 'org' ? 'corporate_fare' : 'source'}
+        </span>
+        <span className="truncate">
+          {runner.scope === 'org' ? runner.owner : `${runner.owner}/${runner.repo}`}
+        </span>
+      </div>
+
+      {/* Runner group */}
+      {runner.runnerGroup && (
+        <div className="flex items-center gap-1.5 text-[11px] text-outline">
+          <span
+            className="material-symbols-outlined leading-none"
+            style={{ fontSize: '13px' }}
+          >
+            group_work
+          </span>
+          <span className="truncate">{runner.runnerGroup}</span>
+        </div>
+      )}
+
+      {/* Labels */}
+      {runner.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {runner.labels.map((label) => (
+            <span
+              key={label}
+              className="px-2 py-0.5 rounded-full bg-primary/10 border border-primary/20 text-[10px] font-medium text-primary/80"
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── RunnerGroup ──────────────────────────────────────────────────────────────
+
+const RunnerGroup = ({ groupName, runners }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-2 mb-3 group w-full text-left"
+      >
+        <span
+          className={`material-symbols-outlined text-outline transition-transform ${
+            collapsed ? '-rotate-90' : ''
+          }`}
+          style={{ fontSize: '16px' }}
+        >
+          expand_more
+        </span>
+        <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant group-hover:text-on-surface transition-colors">
+          {groupName || 'Default'}
+        </span>
+        <span className="ml-1 text-[10px] font-semibold text-outline">({runners.length})</span>
+      </button>
+
+      {!collapsed && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {runners.map((runner) => (
+            <RunnerCard key={runner.id} runner={runner} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── RunnersView ──────────────────────────────────────────────────────────────
+
+const RunnersView = () => {
+  const [runners, setRunners] = useState([]);
+  const [summary, setSummary] = useState({ total: 0, online: 0, busy: 0, offline: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [labelFilter, setLabelFilter] = useState('');
+  const intervalRef = useRef(null);
+
+  const fetchRunners = async () => {
+    try {
+      const filters = {};
+      if (statusFilter !== 'all') filters.status = statusFilter;
+      if (labelFilter) filters.label = labelFilter;
+
+      const data = await apiService.getRunners(filters);
+      setRunners(data.runners ?? []);
+      setSummary(data.summary ?? { total: 0, online: 0, busy: 0, offline: 0 });
+      setError(null);
+    } catch (err) {
+      setError('Failed to fetch runners. Please try again.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Initial fetch + auto-refresh every 30 seconds
+  useEffect(() => {
+    setLoading(true);
+    fetchRunners();
+    intervalRef.current = setInterval(fetchRunners, 30000);
+    return () => clearInterval(intervalRef.current);
+  }, [statusFilter, labelFilter]);
+
+  // Client-side name search filter
+  const filteredRunners = useMemo(() => {
+    if (!searchQuery) return runners;
+    const q = searchQuery.toLowerCase();
+    return runners.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.owner.toLowerCase().includes(q) ||
+        (r.repo && r.repo.toLowerCase().includes(q))
+    );
+  }, [runners, searchQuery]);
+
+  // Group by runner group name
+  const groupedByGroup = useMemo(() => {
+    const groups = {};
+    for (const runner of filteredRunners) {
+      const key = runner.runnerGroup || '';
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(runner);
+    }
+    return groups;
+  }, [filteredRunners]);
+
+  const groupEntries = Object.entries(groupedByGroup).sort(([a], [b]) => a.localeCompare(b));
+
+  // ─── Render ───────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[50vh]">
+        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mt-8 text-center">
+        <p className="text-error text-sm">{error}</p>
+        <button
+          onClick={() => { setLoading(true); fetchRunners(); }}
+          className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-primary/10 border border-primary/20 text-primary text-sm rounded-lg hover:bg-primary/20 transition-colors"
+        >
+          <span className="material-symbols-outlined text-sm">refresh</span>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-6">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-3 border-b border-outline-variant/10">
+        {/* Search */}
+        <div className="relative">
+          <span
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-outline material-symbols-outlined leading-none"
+            style={{ fontSize: '16px' }}
+          >
+            search
+          </span>
+          <input
+            type="text"
+            placeholder="Search runners..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="bg-surface-container-highest rounded-lg pl-9 pr-8 py-1.5 w-56 text-xs text-on-surface border-none outline-none focus:ring-1 focus:ring-primary/40"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-outline hover:text-on-surface material-symbols-outlined leading-none"
+              style={{ fontSize: '14px' }}
+            >
+              close
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* Status filter */}
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="bg-surface-container-highest rounded-lg px-3 py-1.5 text-xs text-on-surface-variant border-none outline-none focus:ring-1 focus:ring-primary/40"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+
+          {/* Label filter */}
+          <div className="relative">
+            <input
+              type="text"
+              placeholder="Filter by label..."
+              value={labelFilter}
+              onChange={(e) => setLabelFilter(e.target.value)}
+              className="bg-surface-container-highest rounded-lg px-3 py-1.5 w-40 text-xs text-on-surface-variant border-none outline-none focus:ring-1 focus:ring-primary/40"
+            />
+          </div>
+
+          {/* Manual refresh */}
+          <button
+            onClick={() => { setLoading(true); fetchRunners(); }}
+            title="Refresh"
+            className="p-1.5 text-on-surface-variant hover:text-primary material-symbols-outlined transition-colors leading-none"
+            style={{ fontSize: '18px' }}
+          >
+            refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Summary stats bar */}
+      <div className="px-6 py-5 flex items-center gap-4 flex-wrap sticky top-0 bg-surface z-40">
+        <h2 className="text-2xl font-extrabold tracking-tighter text-on-surface">Runners</h2>
+        <div className="h-6 w-px bg-outline-variant/20 mx-1" />
+
+        {/* Total */}
+        <div className="flex items-center gap-2 bg-surface-container border border-outline-variant/20 rounded-full pl-2 pr-3 py-1">
+          <span
+            className="material-symbols-outlined text-on-surface-variant leading-none"
+            style={{ fontSize: '14px', fontVariationSettings: "'FILL' 1" }}
+          >
+            precision_manufacturing
+          </span>
+          <span className="text-xs font-bold text-on-surface">{summary.total}</span>
+          <span className="text-[10px] uppercase font-bold text-on-surface-variant/70 tracking-tighter">
+            Total
+          </span>
+        </div>
+
+        {/* Idle/Online */}
+        <div className="flex items-center gap-2 bg-secondary/10 border border-secondary/20 rounded-full pl-2 pr-3 py-1">
+          <span className="w-2 h-2 rounded-full bg-secondary" />
+          <span className="text-xs font-bold text-secondary">{summary.online}</span>
+          <span className="text-[10px] uppercase font-bold text-secondary/70 tracking-tighter">
+            Idle
+          </span>
+        </div>
+
+        {/* Busy */}
+        <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-full pl-2 pr-3 py-1">
+          <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+          <span className="text-xs font-bold text-primary">{summary.busy}</span>
+          <span className="text-[10px] uppercase font-bold text-primary/70 tracking-tighter">
+            Busy
+          </span>
+        </div>
+
+        {/* Offline */}
+        <div className="flex items-center gap-2 bg-error/10 border border-error/20 rounded-full pl-2 pr-3 py-1">
+          <span className="w-2 h-2 rounded-full bg-error" />
+          <span className="text-xs font-bold text-error">{summary.offline}</span>
+          <span className="text-[10px] uppercase font-bold text-error/70 tracking-tighter">
+            Offline
+          </span>
+        </div>
+      </div>
+
+      {/* Runner groups */}
+      <div className="px-6">
+        {filteredRunners.length === 0 ? (
+          <div className="text-center py-16 bg-primary/5 border border-primary/10 rounded-xl">
+            <span
+              className="material-symbols-outlined text-outline mb-3 block"
+              style={{ fontSize: '40px' }}
+            >
+              precision_manufacturing
+            </span>
+            <p className="text-outline text-sm">
+              {runners.length === 0
+                ? 'No self-hosted runners found across your installations.'
+                : 'No runners match your current filters.'}
+            </p>
+          </div>
+        ) : (
+          groupEntries.map(([groupName, groupRunners]) => (
+            <RunnerGroup
+              key={groupName || '__default__'}
+              groupName={groupName}
+              runners={groupRunners}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RunnersView;

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -146,6 +146,7 @@ const RunnersView = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [labelFilter, setLabelFilter] = useState('');
+  const [runnersAvailable, setRunnersAvailable] = useState(null); // null = checking
   const intervalRef = useRef(null);
 
   const fetchRunners = async () => {
@@ -166,13 +167,21 @@ const RunnersView = () => {
     }
   };
 
-  // Initial fetch + auto-refresh every 30 seconds
+  // Permission check on mount
   useEffect(() => {
+    apiService.getRunnersStatus().then((status) => {
+      setRunnersAvailable(status.available === true);
+    });
+  }, []);
+
+  // Initial fetch + auto-refresh every 30 seconds (only when available)
+  useEffect(() => {
+    if (!runnersAvailable) return;
     setLoading(true);
     fetchRunners();
     intervalRef.current = setInterval(fetchRunners, 30000);
     return () => clearInterval(intervalRef.current);
-  }, [statusFilter, labelFilter]);
+  }, [statusFilter, labelFilter, runnersAvailable]);
 
   // Client-side name search filter
   const filteredRunners = useMemo(() => {
@@ -200,6 +209,43 @@ const RunnersView = () => {
   const groupEntries = Object.entries(groupedByGroup).sort(([a], [b]) => a.localeCompare(b));
 
   // ─── Render ───────────────────────────────────────────────────────────────────
+
+  if (runnersAvailable === null) {
+    return (
+      <div className="flex items-center justify-center h-[50vh]">
+        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!runnersAvailable) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[60vh] px-8 text-center">
+        <span
+          className="material-symbols-outlined text-outline mb-4"
+          style={{ fontSize: '48px' }}
+        >
+          lock
+        </span>
+        <h2 className="text-xl font-bold text-on-surface mb-2">Self-Hosted Runners Not Available</h2>
+        <p className="text-sm text-outline max-w-md mb-6">
+          This feature requires the GitHub App to have the{' '}
+          <span className="font-semibold text-on-surface-variant">Self-hosted runners (Read)</span>{' '}
+          organization permission. Please contact your GitHub organization admin to update the app
+          permissions.
+        </p>
+        <a
+          href="https://docs.github.com/en/apps/maintaining-github-apps/editing-a-github-apps-permissions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 border border-primary/20 text-primary text-sm rounded-lg hover:bg-primary/20 transition-colors"
+        >
+          <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>open_in_new</span>
+          GitHub App Permissions Docs
+        </a>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -52,8 +52,9 @@ const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
           {runner.name}
         </span>
         {runner.scope === 'repo' && (
-          <span className="flex-shrink-0 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[8px] font-bold uppercase tracking-wider text-tertiary/80" title={`Repo: ${runner.owner}/${runner.repo}`}>
-            repo
+          <span className="flex-shrink-0 flex items-center gap-1 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[9px] font-medium text-tertiary/80">
+            <span className="material-symbols-outlined leading-none" style={{ fontSize: '10px' }}>source</span>
+            {runner.repo}
           </span>
         )}
       </div>

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -37,115 +37,62 @@ const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
   const meta = statusMeta(runner.status);
 
   return (
-    <div className="bg-surface-container rounded-xl border border-outline-variant/10 p-4 flex flex-col gap-3 hover:bg-surface-container-high transition-all">
-      {/* Header row */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <span
-            className="material-symbols-outlined text-on-surface-variant flex-shrink-0"
-            style={{ fontSize: '18px' }}
-          >
-            {osIcon(runner.os)}
-          </span>
-          <span className="font-semibold text-sm text-on-surface truncate" title={runner.name}>
-            {runner.name}
-          </span>
-        </div>
-        <button
-          onClick={() => onStatusClick && onStatusClick(runner.status)}
-          className="flex items-center gap-1.5 flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
-          title={`Filter by ${meta.label}`}
-        >
-          <span className={`w-2 h-2 rounded-full ${meta.dot}`} />
-          <span className={`text-xs font-semibold ${meta.text}`}>{meta.label}</span>
-        </button>
-      </div>
+    <div className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-surface-container-high transition-all group">
+      {/* OS icon */}
+      <span
+        className="material-symbols-outlined text-on-surface-variant flex-shrink-0"
+        style={{ fontSize: '16px' }}
+      >
+        {osIcon(runner.os)}
+      </span>
 
-      {/* Scope */}
-      <div className="flex items-center gap-1.5 text-[11px] text-outline">
-        <span
-          className="material-symbols-outlined leading-none"
-          style={{ fontSize: '13px' }}
-        >
-          {runner.scope === 'org' ? 'corporate_fare' : 'source'}
-        </span>
-        <span className="truncate">
-          {runner.scope === 'org' ? runner.owner : `${runner.owner}/${runner.repo}`}
-        </span>
-      </div>
+      {/* Name */}
+      <span className="font-semibold text-xs text-on-surface truncate min-w-[120px] max-w-[180px]" title={runner.name}>
+        {runner.name}
+      </span>
 
-      {/* Runner group */}
-      {runner.runnerGroup && (
-        <div className="flex items-center gap-1.5 text-[11px] text-outline">
-          <span
-            className="material-symbols-outlined leading-none"
-            style={{ fontSize: '13px' }}
-          >
-            group_work
-          </span>
-          <span className="truncate">{runner.runnerGroup}</span>
-        </div>
-      )}
+      {/* Status */}
+      <button
+        onClick={() => onStatusClick && onStatusClick(runner.status)}
+        className="flex items-center gap-1.5 flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity min-w-[52px]"
+        title={`Filter by ${meta.label}`}
+      >
+        <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
+        <span className={`text-[10px] font-semibold ${meta.text}`}>{meta.label}</span>
+      </button>
 
-      {/* Active job (when busy) */}
+      {/* Active job (compact) */}
       {runner.status === 'busy' && runner.activeJob && (
-        <div className="flex flex-col gap-1.5 bg-primary/5 border border-primary/10 rounded-lg px-3 py-2">
-          <div className="flex items-center gap-1.5 text-[11px] text-primary/80">
-            <span
-              className="material-symbols-outlined leading-none"
-              style={{ fontSize: '13px' }}
-            >
-              play_circle
-            </span>
-            <span className="font-semibold truncate">{runner.activeJob.workflowName || 'Workflow'}</span>
-            {runner.activeJob.jobName && (
-              <span className="text-primary/50 truncate">/ {runner.activeJob.jobName}</span>
-            )}
-          </div>
-          {runner.activeJob.repository && (
-            <div className="text-[10px] text-primary/50 truncate ml-[21px]">{runner.activeJob.repository}</div>
+        <div className="flex items-center gap-1.5 text-[10px] text-primary/70 truncate min-w-0">
+          <span className="material-symbols-outlined leading-none flex-shrink-0" style={{ fontSize: '11px' }}>play_circle</span>
+          <span className="truncate">{runner.activeJob.workflowName || 'Workflow'}{runner.activeJob.jobName ? ` / ${runner.activeJob.jobName}` : ''}</span>
+          {runner.activeJob.workflowRunId && (
+            <a href={`/workflow/${runner.activeJob.workflowRunId}`} className="text-primary hover:underline flex-shrink-0" title="View in RunWatch">↗</a>
           )}
-          <div className="flex items-center gap-2 ml-[21px]">
-            {runner.activeJob.workflowRunId && (
-              <a
-                href={`/workflow/${runner.activeJob.workflowRunId}`}
-                className="text-[10px] font-medium text-primary hover:text-primary/80 hover:underline transition-colors"
-                title="View in RunWatch"
-              >
-                RunWatch →
-              </a>
-            )}
-            {runner.activeJob.workflowRunUrl && (
-              <a
-                href={runner.activeJob.workflowRunUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[10px] font-medium text-primary/60 hover:text-primary/80 hover:underline transition-colors flex items-center gap-0.5"
-                title="View on GitHub"
-              >
-                GitHub
-                <span className="material-symbols-outlined" style={{ fontSize: '10px' }}>open_in_new</span>
-              </a>
-            )}
-          </div>
+          {runner.activeJob.workflowRunUrl && (
+            <a href={runner.activeJob.workflowRunUrl} target="_blank" rel="noopener noreferrer" className="text-primary/50 hover:text-primary/80 flex-shrink-0" title="View on GitHub">
+              <span className="material-symbols-outlined" style={{ fontSize: '10px' }}>open_in_new</span>
+            </a>
+          )}
         </div>
       )}
 
       {/* Labels */}
-      {runner.labels.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {runner.labels.map((label) => (
-            <button
-              key={label}
-              onClick={() => onLabelClick && onLabelClick(label)}
-              className="px-2 py-0.5 rounded-full bg-primary/10 border border-primary/20 text-[10px] font-medium text-primary/80 hover:bg-primary/20 hover:text-primary transition-colors cursor-pointer"
-              title={`Filter by "${label}"`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      )}
+      <div className="flex items-center gap-1 ml-auto flex-shrink-0">
+        {runner.labels.slice(0, 4).map((label) => (
+          <button
+            key={label}
+            onClick={() => onLabelClick && onLabelClick(label)}
+            className="px-1.5 py-0 rounded-full bg-primary/10 border border-primary/20 text-[9px] font-medium text-primary/70 hover:bg-primary/20 hover:text-primary transition-colors cursor-pointer leading-relaxed"
+            title={`Filter by "${label}"`}
+          >
+            {label}
+          </button>
+        ))}
+        {runner.labels.length > 4 && (
+          <span className="text-[9px] text-outline" title={runner.labels.slice(4).join(', ')}>+{runner.labels.length - 4}</span>
+        )}
+      </div>
     </div>
   );
 };
@@ -176,7 +123,7 @@ const RunnerGroup = ({ groupName, runners, onLabelClick, onStatusClick }) => {
       </button>
 
       {!collapsed && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+        <div className="flex flex-col">
           {runners.map((runner) => (
             <RunnerCard key={runner.id} runner={runner} onLabelClick={onLabelClick} onStatusClick={onStatusClick} />
           ))}

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -278,9 +278,11 @@ const RunnersView = () => {
   const [statusFilter, setStatusFilter] = useState('all');
   const [labelFilter, setLabelFilter] = useState('');
   const [runnersAvailable, setRunnersAvailable] = useState(null); // null = checking
+  const [lastUpdated, setLastUpdated] = useState(null);
   const intervalRef = useRef(null);
 
-  const fetchRunners = async () => {
+  const fetchRunners = async (showLoading = false) => {
+    if (showLoading) setLoading(true);
     try {
       const filters = {};
       if (statusFilter !== 'all') filters.status = statusFilter;
@@ -289,6 +291,7 @@ const RunnersView = () => {
       setRunners(data.runners ?? []);
       setSummary(data.summary ?? { total: 0, online: 0, busy: 0, offline: 0 });
       setError(null);
+      setLastUpdated(new Date());
     } catch (err) {
       setError('Failed to fetch runners. Please try again.');
       console.error(err);
@@ -307,9 +310,8 @@ const RunnersView = () => {
   // Initial fetch + auto-refresh every 30 seconds (only when available)
   useEffect(() => {
     if (!runnersAvailable) return;
-    setLoading(true);
-    fetchRunners();
-    intervalRef.current = setInterval(fetchRunners, 30000);
+    fetchRunners(true); // Show spinner only on initial load
+    intervalRef.current = setInterval(() => fetchRunners(false), 30000); // Silent refresh
     return () => clearInterval(intervalRef.current);
   }, [statusFilter, runnersAvailable]);
 
@@ -406,7 +408,7 @@ const RunnersView = () => {
       <div className="mt-8 text-center">
         <p className="text-error text-sm">{error}</p>
         <button
-          onClick={() => { setLoading(true); fetchRunners(); }}
+          onClick={() => { fetchRunners(true); }}
           className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-primary/10 border border-primary/20 text-primary text-sm rounded-lg hover:bg-primary/20 transition-colors"
         >
           <span className="material-symbols-outlined text-sm">refresh</span>
@@ -482,7 +484,7 @@ const RunnersView = () => {
 
           {/* Manual refresh */}
           <button
-            onClick={() => { setLoading(true); fetchRunners(); }}
+            onClick={() => { fetchRunners(true); }}
             title="Refresh"
             className="p-1.5 text-on-surface-variant hover:text-primary material-symbols-outlined transition-colors leading-none"
             style={{ fontSize: '18px' }}

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -434,32 +434,66 @@ const RunnersView = () => {
     <div className="pb-6">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-3 border-b border-outline-variant/10">
-        {/* Search */}
-        <div className="relative">
-          <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-outline material-symbols-outlined leading-none"
-            style={{ fontSize: '16px' }}
+        {/* Left: Search + Cache info + Refresh */}
+        <div className="flex items-center gap-3">
+          {/* Search */}
+          <div className="relative">
+            <span
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-outline material-symbols-outlined leading-none"
+              style={{ fontSize: '16px' }}
+            >
+              search
+            </span>
+            <input
+              type="text"
+              placeholder="Search runners..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="bg-surface-container-highest rounded-lg pl-9 pr-8 py-1.5 w-56 text-xs text-on-surface border-none outline-none focus:ring-1 focus:ring-primary/40"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-outline hover:text-on-surface material-symbols-outlined leading-none"
+                style={{ fontSize: '14px' }}
+              >
+                close
+              </button>
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="h-5 w-px bg-outline-variant/20" />
+
+          {/* Cache info + Force refresh */}
+          {cacheInfo && cacheInfo.cachedAt && (
+            <span className="text-[10px] text-on-surface-variant/40" title={`Cache TTL: ${Math.round(cacheInfo.ttlMs / 1000)}s`}>
+              {cacheInfo.ageMs != null
+                ? `Cached ${Math.round(cacheInfo.ageMs / 1000)}s ago`
+                : 'Fresh'}
+            </span>
+          )}
+          <button
+            onClick={handleForceRefresh}
+            disabled={refreshing}
+            title="Force refresh (bypass cache)"
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              refreshing
+                ? 'bg-primary/10 text-primary'
+                : 'bg-surface-container-highest text-on-surface-variant hover:text-primary hover:bg-primary/10'
+            }`}
           >
-            search
-          </span>
-          <input
-            type="text"
-            placeholder="Search runners..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="bg-surface-container-highest rounded-lg pl-9 pr-8 py-1.5 w-56 text-xs text-on-surface border-none outline-none focus:ring-1 focus:ring-primary/40"
-          />
-          {searchQuery && (
-            <button
-              onClick={() => setSearchQuery('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-outline hover:text-on-surface material-symbols-outlined leading-none"
+            <span
+              className={`material-symbols-outlined leading-none ${refreshing ? 'animate-spin' : ''}`}
               style={{ fontSize: '14px' }}
             >
-              close
-            </button>
-          )}
+              refresh
+            </span>
+            {refreshing ? 'Refreshing...' : 'Refresh'}
+          </button>
         </div>
 
+        {/* Right: Filters */}
         <div className="flex items-center gap-3">
           {/* Status filter */}
           <select
@@ -492,30 +526,6 @@ const RunnersView = () => {
                 close
               </button>
             )}
-          </div>
-
-          {/* Cache info + refresh */}
-          <div className="flex items-center gap-2">
-            {cacheInfo && cacheInfo.cachedAt && (
-              <span className="text-[10px] text-on-surface-variant/40" title={`Cache TTL: ${Math.round(cacheInfo.ttlMs / 1000)}s`}>
-                {cacheInfo.ageMs != null
-                  ? `Cached ${Math.round(cacheInfo.ageMs / 1000)}s ago`
-                  : 'Fresh'}
-              </span>
-            )}
-            <button
-              onClick={handleForceRefresh}
-              disabled={refreshing}
-              title="Force refresh (bypass cache)"
-              className={`p-1.5 material-symbols-outlined transition-colors leading-none ${
-                refreshing
-                  ? 'text-primary animate-spin'
-                  : 'text-on-surface-variant hover:text-primary'
-              }`}
-              style={{ fontSize: '18px' }}
-            >
-              refresh
-            </button>
           </div>
         </div>
       </div>

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -277,6 +277,7 @@ const OrgSection = ({ orgName, runners, onLabelClick, onStatusClick }) => {
 const RunnersView = () => {
   const [runners, setRunners] = useState([]);
   const [summary, setSummary] = useState({ total: 0, online: 0, busy: 0, offline: 0 });
+  const [totalSummary, setTotalSummary] = useState({ total: 0, online: 0, busy: 0, offline: 0 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -290,12 +291,14 @@ const RunnersView = () => {
   const fetchRunners = async (showLoading = false) => {
     if (showLoading) setLoading(true);
     try {
-      const filters = {};
-      if (statusFilter !== 'all') filters.status = statusFilter;
-
-      const data = await apiService.getRunners(filters);
-      setRunners(data.runners ?? []);
-      setSummary(data.summary ?? { total: 0, online: 0, busy: 0, offline: 0 });
+      // Always fetch ALL runners (no status filter on server)
+      // so we can compute accurate total counts
+      const data = await apiService.getRunners({});
+      const allRunners = data.runners ?? [];
+      const allSummary = data.summary ?? { total: 0, online: 0, busy: 0, offline: 0 };
+      setTotalSummary(allSummary);
+      setRunners(allRunners);
+      setSummary(allSummary);
       setCacheInfo(data.cache ?? null);
       setError(null);
     } catch (err) {
@@ -330,11 +333,15 @@ const RunnersView = () => {
     fetchRunners(true); // Show spinner only on initial load
     intervalRef.current = setInterval(() => fetchRunners(false), 30000); // Silent refresh
     return () => clearInterval(intervalRef.current);
-  }, [statusFilter, runnersAvailable]);
+  }, [runnersAvailable]);
 
-  // Client-side name search filter
+  // Client-side filtering (search, status, label)
   const filteredRunners = useMemo(() => {
     let result = runners;
+
+    if (statusFilter !== 'all') {
+      result = result.filter((r) => r.status === statusFilter);
+    }
 
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
@@ -354,7 +361,7 @@ const RunnersView = () => {
     }
 
     return result;
-  }, [runners, searchQuery, labelFilter]);
+  }, [runners, searchQuery, labelFilter, statusFilter]);
 
   const handleLabelClick = useCallback((label) => {
     setLabelFilter(label);
@@ -558,7 +565,7 @@ const RunnersView = () => {
           >
             precision_manufacturing
           </span>
-          <span className="text-xs font-bold text-on-surface">{summary.total}</span>
+          <span className="text-xs font-bold text-on-surface">{totalSummary.total}</span>
           <span className="text-[10px] uppercase font-bold text-on-surface-variant/70 tracking-tighter">
             Total
           </span>
@@ -573,7 +580,7 @@ const RunnersView = () => {
           title="Filter by Idle"
         >
           <span className="w-2 h-2 rounded-full bg-secondary" />
-          <span className="text-xs font-bold text-secondary">{summary.online}</span>
+          <span className="text-xs font-bold text-secondary">{totalSummary.online}</span>
           <span className="text-[10px] uppercase font-bold text-secondary/70 tracking-tighter">
             Idle
           </span>
@@ -588,7 +595,7 @@ const RunnersView = () => {
           title="Filter by Busy"
         >
           <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
-          <span className="text-xs font-bold text-primary">{summary.busy}</span>
+          <span className="text-xs font-bold text-primary">{totalSummary.busy}</span>
           <span className="text-[10px] uppercase font-bold text-primary/70 tracking-tighter">
             Busy
           </span>
@@ -603,7 +610,7 @@ const RunnersView = () => {
           title="Filter by Offline"
         >
           <span className="w-2 h-2 rounded-full bg-error" />
-          <span className="text-xs font-bold text-error">{summary.offline}</span>
+          <span className="text-xs font-bold text-error">{totalSummary.offline}</span>
           <span className="text-[10px] uppercase font-bold text-error/70 tracking-tighter">
             Offline
           </span>

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -53,7 +53,8 @@ const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
         </span>
         {runner.scope === 'repo' && runner.repo && (
           <span className="flex-shrink-0 flex items-center gap-1.5 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[9px] font-medium text-tertiary/80">
-            <span className="material-symbols-outlined leading-none" style={{ fontSize: '10px' }}>source</span>
+            <span className="font-bold uppercase tracking-wider">repo</span>
+            <span className="text-tertiary/40">-</span>
             <a
               href={`/repository/${runner.owner}/${runner.repo}`}
               className="hover:text-tertiary hover:underline transition-colors"

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -46,10 +46,17 @@ const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
         {osIcon(runner.os)}
       </span>
 
-      {/* Name */}
-      <span className="font-semibold text-xs text-on-surface truncate min-w-[120px] max-w-[180px]" title={runner.name}>
-        {runner.name}
-      </span>
+      {/* Name + scope badge */}
+      <div className="flex items-center gap-1.5 min-w-[120px] max-w-[220px]">
+        <span className="font-semibold text-xs text-on-surface truncate" title={runner.name}>
+          {runner.name}
+        </span>
+        {runner.scope === 'repo' && (
+          <span className="flex-shrink-0 px-1.5 py-0 rounded bg-tertiary/15 border border-tertiary/20 text-[8px] font-bold uppercase tracking-wider text-tertiary/80" title={`Repo: ${runner.owner}/${runner.repo}`}>
+            repo
+          </span>
+        )}
+      </div>
 
       {/* Status */}
       <button

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -296,7 +296,6 @@ const RunnersView = () => {
   const handleLabelClick = useCallback((label) => {
     setLabelFilter(label);
   }, []);
-  }, [runners, searchQuery]);
 
   // Group by org
   const groupedByOrg = useMemo(() => {

--- a/client/src/features/runners/RunnersView.jsx
+++ b/client/src/features/runners/RunnersView.jsx
@@ -33,7 +33,7 @@ const osIcon = (os) => {
 
 // ─── RunnerCard ────────────────────────────────────────────────────────────────
 
-const RunnerCard = ({ runner, onLabelClick }) => {
+const RunnerCard = ({ runner, onLabelClick, onStatusClick }) => {
   const meta = statusMeta(runner.status);
 
   return (
@@ -51,10 +51,14 @@ const RunnerCard = ({ runner, onLabelClick }) => {
             {runner.name}
           </span>
         </div>
-        <div className="flex items-center gap-1.5 flex-shrink-0">
+        <button
+          onClick={() => onStatusClick && onStatusClick(runner.status)}
+          className="flex items-center gap-1.5 flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
+          title={`Filter by ${meta.label}`}
+        >
           <span className={`w-2 h-2 rounded-full ${meta.dot}`} />
           <span className={`text-xs font-semibold ${meta.text}`}>{meta.label}</span>
-        </div>
+        </button>
       </div>
 
       {/* Scope */}
@@ -148,7 +152,7 @@ const RunnerCard = ({ runner, onLabelClick }) => {
 
 // ─── RunnerGroup ──────────────────────────────────────────────────────────────
 
-const RunnerGroup = ({ groupName, runners, onLabelClick }) => {
+const RunnerGroup = ({ groupName, runners, onLabelClick, onStatusClick }) => {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
@@ -174,7 +178,7 @@ const RunnerGroup = ({ groupName, runners, onLabelClick }) => {
       {!collapsed && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
           {runners.map((runner) => (
-            <RunnerCard key={runner.id} runner={runner} onLabelClick={onLabelClick} />
+            <RunnerCard key={runner.id} runner={runner} onLabelClick={onLabelClick} onStatusClick={onStatusClick} />
           ))}
         </div>
       )}
@@ -184,7 +188,7 @@ const RunnerGroup = ({ groupName, runners, onLabelClick }) => {
 
 // ─── OrgSection ───────────────────────────────────────────────────────────────
 
-const OrgSection = ({ orgName, runners, onLabelClick }) => {
+const OrgSection = ({ orgName, runners, onLabelClick, onStatusClick }) => {
   const [collapsed, setCollapsed] = useState(false);
 
   // Group runners by runner group within this org
@@ -259,6 +263,7 @@ const OrgSection = ({ orgName, runners, onLabelClick }) => {
               groupName={groupName}
               runners={groupRunners}
               onLabelClick={onLabelClick}
+              onStatusClick={onStatusClick}
             />
           ))}
         </div>
@@ -353,6 +358,10 @@ const RunnersView = () => {
 
   const handleLabelClick = useCallback((label) => {
     setLabelFilter(label);
+  }, []);
+
+  const handleStatusClick = useCallback((status) => {
+    setStatusFilter((prev) => (prev === status ? 'all' : status));
   }, []);
 
   // Group by org
@@ -536,7 +545,13 @@ const RunnersView = () => {
         <div className="h-6 w-px bg-outline-variant/20 mx-1" />
 
         {/* Total */}
-        <div className="flex items-center gap-2 bg-surface-container border border-outline-variant/20 rounded-full pl-2 pr-3 py-1">
+        <button
+          onClick={() => setStatusFilter('all')}
+          className={`flex items-center gap-2 bg-surface-container border rounded-full pl-2 pr-3 py-1 transition-all cursor-pointer hover:bg-surface-container-high ${
+            statusFilter === 'all' ? 'border-on-surface/40 ring-1 ring-on-surface/20' : 'border-outline-variant/20'
+          }`}
+          title="Show all runners"
+        >
           <span
             className="material-symbols-outlined text-on-surface-variant leading-none"
             style={{ fontSize: '14px', fontVariationSettings: "'FILL' 1" }}
@@ -547,34 +562,52 @@ const RunnersView = () => {
           <span className="text-[10px] uppercase font-bold text-on-surface-variant/70 tracking-tighter">
             Total
           </span>
-        </div>
+        </button>
 
         {/* Idle/Online */}
-        <div className="flex items-center gap-2 bg-secondary/10 border border-secondary/20 rounded-full pl-2 pr-3 py-1">
+        <button
+          onClick={() => setStatusFilter(statusFilter === 'idle' ? 'all' : 'idle')}
+          className={`flex items-center gap-2 bg-secondary/10 border rounded-full pl-2 pr-3 py-1 transition-all cursor-pointer hover:bg-secondary/20 ${
+            statusFilter === 'idle' ? 'border-secondary/60 ring-1 ring-secondary/30' : 'border-secondary/20'
+          }`}
+          title="Filter by Idle"
+        >
           <span className="w-2 h-2 rounded-full bg-secondary" />
           <span className="text-xs font-bold text-secondary">{summary.online}</span>
           <span className="text-[10px] uppercase font-bold text-secondary/70 tracking-tighter">
             Idle
           </span>
-        </div>
+        </button>
 
         {/* Busy */}
-        <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-full pl-2 pr-3 py-1">
+        <button
+          onClick={() => setStatusFilter(statusFilter === 'busy' ? 'all' : 'busy')}
+          className={`flex items-center gap-2 bg-primary/10 border rounded-full pl-2 pr-3 py-1 transition-all cursor-pointer hover:bg-primary/20 ${
+            statusFilter === 'busy' ? 'border-primary/60 ring-1 ring-primary/30' : 'border-primary/20'
+          }`}
+          title="Filter by Busy"
+        >
           <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
           <span className="text-xs font-bold text-primary">{summary.busy}</span>
           <span className="text-[10px] uppercase font-bold text-primary/70 tracking-tighter">
             Busy
           </span>
-        </div>
+        </button>
 
         {/* Offline */}
-        <div className="flex items-center gap-2 bg-error/10 border border-error/20 rounded-full pl-2 pr-3 py-1">
+        <button
+          onClick={() => setStatusFilter(statusFilter === 'offline' ? 'all' : 'offline')}
+          className={`flex items-center gap-2 bg-error/10 border rounded-full pl-2 pr-3 py-1 transition-all cursor-pointer hover:bg-error/20 ${
+            statusFilter === 'offline' ? 'border-error/60 ring-1 ring-error/30' : 'border-error/20'
+          }`}
+          title="Filter by Offline"
+        >
           <span className="w-2 h-2 rounded-full bg-error" />
           <span className="text-xs font-bold text-error">{summary.offline}</span>
           <span className="text-[10px] uppercase font-bold text-error/70 tracking-tighter">
             Offline
           </span>
-        </div>
+        </button>
       </div>
 
       {/* Runners grouped by org */}
@@ -600,6 +633,7 @@ const RunnersView = () => {
               orgName={orgName}
               runners={orgRunners}
               onLabelClick={handleLabelClick}
+              onStatusClick={handleStatusClick}
             />
           ))
         )}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm install --production
+# Install dependencies strictly from lockfile
+RUN npm ci --omit=dev
 
 # Copy source code
 COPY . .

--- a/server/src/controllers/runnerController.js
+++ b/server/src/controllers/runnerController.js
@@ -48,17 +48,27 @@ export const checkRunnersStatus = async (req, res) => {
       return successResponse(res, result, 'Runner permission status');
     }
 
+    console.log(`runnerController.checkRunnersStatus: probing installation ${installation.id} (${account.login}, type=${account.type})`);
+
     if (account.type === 'Organization') {
       await client.rest.actions.listSelfHostedRunnersForOrg({ org: account.login, per_page: 1 });
     } else {
+      // For user-level installations, try repo-level runners API
       const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({ per_page: 1 });
       if (reposData.repositories && reposData.repositories.length > 0) {
         const repo = reposData.repositories[0];
+        console.log(`runnerController.checkRunnersStatus: probing repo ${repo.full_name}`);
         await client.rest.actions.listSelfHostedRunnersForRepo({
           owner: repo.owner.login,
           repo: repo.name,
           per_page: 1,
         });
+      } else {
+        console.log('runnerController.checkRunnersStatus: no accessible repos found for installation');
+        const result = { available: false, reason: 'No accessible repositories found for this installation' };
+        permissionCache.result = result;
+        permissionCache.fetchedAt = Date.now();
+        return successResponse(res, result, 'Runner permission status');
       }
     }
 
@@ -67,13 +77,14 @@ export const checkRunnersStatus = async (req, res) => {
     permissionCache.fetchedAt = Date.now();
     return successResponse(res, result, 'Runner permission status');
   } catch (err) {
+    console.error(`runnerController.checkRunnersStatus: probe failed — status=${err.status}, message=${err.message}`);
     let result;
     if (err.status === 403) {
       result = { available: false, reason: 'GitHub App lacks Self-hosted runners (Read) permission' };
     } else if (err.status === 404) {
       result = { available: false, reason: 'Runners API not accessible for this installation' };
     } else {
-      result = { available: false, reason: 'Unable to verify runner permissions' };
+      result = { available: false, reason: `Unable to verify runner permissions: ${err.message}` };
     }
     permissionCache.result = result;
     permissionCache.fetchedAt = Date.now();

--- a/server/src/controllers/runnerController.js
+++ b/server/src/controllers/runnerController.js
@@ -1,10 +1,85 @@
 import { successResponse, errorResponse } from '../utils/responseHandler.js';
 import * as runnerService from '../services/runnerService.js';
+import { getGitHubClient } from '../utils/githubAuth.js';
 
 // Sanitize external values before embedding in log messages to prevent log injection.
 const sanitizeLog = (v) => (v == null ? '' : String(v).replace(/[\r\n\t\x00-\x1F\x7F]/g, ' '));
 
 const VALID_STATUSES = new Set(['all', 'online', 'busy', 'idle', 'offline']);
+
+// Permission check cache (5-minute TTL)
+const permissionCache = { result: null, fetchedAt: null, TTL_MS: 5 * 60 * 1000 };
+
+/**
+ * GET /runners/status
+ * Checks whether the GitHub App has the Self-hosted runners (Read) permission.
+ * Result is cached for 5 minutes.
+ */
+export const checkRunnersStatus = async (req, res) => {
+  if (
+    permissionCache.result !== null &&
+    permissionCache.fetchedAt !== null &&
+    Date.now() - permissionCache.fetchedAt < permissionCache.TTL_MS
+  ) {
+    return successResponse(res, permissionCache.result, 'Runner permission status');
+  }
+
+  try {
+    const { installations } = await getGitHubClient();
+
+    if (!installations || installations.length === 0) {
+      const result = { available: false, reason: 'No GitHub App installations found' };
+      permissionCache.result = result;
+      permissionCache.fetchedAt = Date.now();
+      return successResponse(res, result, 'Runner permission status');
+    }
+
+    const installation = installations[0];
+    const account = installation.account;
+
+    let client;
+    try {
+      const r = await getGitHubClient(installation.id);
+      client = r.app;
+    } catch {
+      const result = { available: false, reason: 'Failed to authenticate with GitHub App' };
+      permissionCache.result = result;
+      permissionCache.fetchedAt = Date.now();
+      return successResponse(res, result, 'Runner permission status');
+    }
+
+    if (account.type === 'Organization') {
+      await client.rest.actions.listSelfHostedRunnersForOrg({ org: account.login, per_page: 1 });
+    } else {
+      const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({ per_page: 1 });
+      if (reposData.repositories && reposData.repositories.length > 0) {
+        const repo = reposData.repositories[0];
+        await client.rest.actions.listSelfHostedRunnersForRepo({
+          owner: repo.owner.login,
+          repo: repo.name,
+          per_page: 1,
+        });
+      }
+    }
+
+    const result = { available: true, reason: 'Self-hosted runners permission granted' };
+    permissionCache.result = result;
+    permissionCache.fetchedAt = Date.now();
+    return successResponse(res, result, 'Runner permission status');
+  } catch (err) {
+    let result;
+    if (err.status === 403) {
+      result = { available: false, reason: 'GitHub App lacks Self-hosted runners (Read) permission' };
+    } else if (err.status === 404) {
+      result = { available: false, reason: 'Runners API not accessible for this installation' };
+    } else {
+      result = { available: false, reason: 'Unable to verify runner permissions' };
+    }
+    permissionCache.result = result;
+    permissionCache.fetchedAt = Date.now();
+    return successResponse(res, result, 'Runner permission status');
+  }
+};
 
 /**
  * GET /runners

--- a/server/src/controllers/runnerController.js
+++ b/server/src/controllers/runnerController.js
@@ -134,11 +134,22 @@ export const listRunners = async (req, res) => {
       offline: runners.filter((r) => r.status === 'offline').length,
     };
 
-    return successResponse(res, { runners, summary }, 'Runners fetched successfully');
+    const cacheInfo = runnerService.getCacheInfo();
+
+    return successResponse(res, { runners, summary, cache: cacheInfo }, 'Runners fetched successfully');
   } catch (error) {
     console.error('runnerController.listRunners error:', error);
     return errorResponse(res, 'Failed to fetch runners', 500, error);
   }
+};
+
+/**
+ * POST /runners/cache/invalidate
+ * Force-clear the runner cache so the next GET /runners fetches fresh data.
+ */
+export const invalidateCache = async (req, res) => {
+  runnerService.invalidateCache();
+  return successResponse(res, { invalidated: true }, 'Runner cache invalidated');
 };
 
 /**

--- a/server/src/controllers/runnerController.js
+++ b/server/src/controllers/runnerController.js
@@ -1,0 +1,77 @@
+import { successResponse, errorResponse } from '../utils/responseHandler.js';
+import * as runnerService from '../services/runnerService.js';
+
+// Sanitize external values before embedding in log messages to prevent log injection.
+const sanitizeLog = (v) => (v == null ? '' : String(v).replace(/[\r\n\t\x00-\x1F\x7F]/g, ' '));
+
+const VALID_STATUSES = new Set(['all', 'online', 'busy', 'idle', 'offline']);
+
+/**
+ * GET /runners
+ * Query params: status (all|online|busy|idle|offline), label, group
+ */
+export const listRunners = async (req, res) => {
+  try {
+    const { status = 'all', label = '', group = '' } = req.query;
+
+    if (!VALID_STATUSES.has(status)) {
+      return errorResponse(res, `Invalid status filter: ${sanitizeLog(status)}`, 400);
+    }
+
+    let runners = await runnerService.getAllRunners();
+
+    if (status !== 'all') {
+      runners = runners.filter((r) => r.status === status);
+    }
+
+    if (label) {
+      const labelFilter = String(label).slice(0, 100).toLowerCase();
+      runners = runners.filter((r) =>
+        r.labels.some((l) => l.toLowerCase().includes(labelFilter))
+      );
+    }
+
+    if (group) {
+      const groupFilter = String(group).slice(0, 100).toLowerCase();
+      runners = runners.filter(
+        (r) => r.runnerGroup && r.runnerGroup.toLowerCase().includes(groupFilter)
+      );
+    }
+
+    const summary = {
+      total: runners.length,
+      online: runners.filter((r) => r.status === 'idle').length,
+      busy: runners.filter((r) => r.status === 'busy').length,
+      offline: runners.filter((r) => r.status === 'offline').length,
+    };
+
+    return successResponse(res, { runners, summary }, 'Runners fetched successfully');
+  } catch (error) {
+    console.error('runnerController.listRunners error:', error);
+    return errorResponse(res, 'Failed to fetch runners', 500, error);
+  }
+};
+
+/**
+ * GET /runners/:runnerId
+ */
+export const getRunner = async (req, res) => {
+  try {
+    const { runnerId } = req.params;
+
+    if (!/^\d+$/.test(runnerId)) {
+      return errorResponse(res, 'Invalid runner ID', 400);
+    }
+
+    const runner = await runnerService.getRunnerById(runnerId);
+
+    if (!runner) {
+      return errorResponse(res, 'Runner not found', 404);
+    }
+
+    return successResponse(res, runner, 'Runner fetched successfully');
+  } catch (error) {
+    console.error('runnerController.getRunner error:', sanitizeLog(req.params?.runnerId), error);
+    return errorResponse(res, 'Failed to fetch runner', 500, error);
+  }
+};

--- a/server/src/controllers/runnerController.js
+++ b/server/src/controllers/runnerController.js
@@ -124,6 +124,9 @@ export const listRunners = async (req, res) => {
       );
     }
 
+    // Enrich busy runners with active workflow/job info from RunWatch DB
+    runners = await runnerService.enrichRunnersWithActiveJobs(runners);
+
     const summary = {
       total: runners.length,
       online: runners.filter((r) => r.status === 'idle').length,

--- a/server/src/middleware/socket.js
+++ b/server/src/middleware/socket.js
@@ -44,6 +44,10 @@ const setupSocket = (server) => {
     // Clients cannot send or receive a 'long-queued-workflow' Socket.IO event, and the
     // server does not emit it via io.emit().
 
+    // runnerStatusUpdate: emitted by the server when self-hosted runner status changes.
+    // Payload: { runners: Array, summary: { total, online, busy, offline } }
+    // Clients (RunnersView) can listen with: socket.on('runnerStatusUpdate', handler)
+
     socket.on('disconnect', () => {
       console.log('Client disconnected:', socket.id);
     });

--- a/server/src/routes/api.js
+++ b/server/src/routes/api.js
@@ -60,6 +60,7 @@ const restoreJsonParser = express.json({ limit: '100mb' });
 router.post('/database/restore', workflowController.requireAdminToken, restoreJsonParser, workflowController.restoreBackup);
 
 // Self-hosted runners
+router.get('/runners/status', runnerController.checkRunnersStatus);
 router.get('/runners', runnerController.listRunners);
 router.get('/runners/:runnerId', runnerController.getRunner);
 

--- a/server/src/routes/api.js
+++ b/server/src/routes/api.js
@@ -61,6 +61,7 @@ router.post('/database/restore', workflowController.requireAdminToken, restoreJs
 
 // Self-hosted runners
 router.get('/runners/status', runnerController.checkRunnersStatus);
+router.post('/runners/cache/invalidate', runnerController.invalidateCache);
 router.get('/runners', runnerController.listRunners);
 router.get('/runners/:runnerId', runnerController.getRunner);
 

--- a/server/src/routes/api.js
+++ b/server/src/routes/api.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import * as workflowController from '../controllers/workflowController.js';
+import * as runnerController from '../controllers/runnerController.js';
 import { syncGitHubData, getAvailableOrganizations, getSyncHistory } from '../services/syncService.js';
 import { validateGitHubConfig } from '../utils/githubAuth.js';
 import SyncHistory from '../models/SyncHistory.js';
@@ -57,6 +58,10 @@ router.get('/database/backup', workflowController.requireAdminToken, workflowCon
 // Restore uses a 100mb body limit (applied AFTER auth to prevent unauthenticated memory exhaustion).
 const restoreJsonParser = express.json({ limit: '100mb' });
 router.post('/database/restore', workflowController.requireAdminToken, restoreJsonParser, workflowController.restoreBackup);
+
+// Self-hosted runners
+router.get('/runners', runnerController.listRunners);
+router.get('/runners/:runnerId', runnerController.getRunner);
 
 // Get available organizations
 router.get('/organizations', async (req, res) => {

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -147,8 +147,47 @@ const fetchInstallationRunners = async (installation) => {
         err.message
       );
     }
-    // Skip repo-level fetching for orgs — org runners are already visible
-    // to all repos, and repo-level calls mostly return 403.
+
+    // Also fetch repo-level runners (repos can have their own runners
+    // in addition to org-shared ones). Runs in parallel, skips 403s.
+    try {
+      const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({
+        per_page: 100,
+      });
+
+      if (reposData.repositories && reposData.repositories.length > 0) {
+        // Track org runner IDs to avoid duplicates
+        const orgRunnerIds = new Set(runners.map((r) => r.id));
+
+        const repoResults = await Promise.allSettled(
+          reposData.repositories.map(async (repo) => {
+            const { data: runnerData } = await client.rest.actions.listSelfHostedRunnersForRepo({
+              owner: repo.owner.login,
+              repo: repo.name,
+              per_page: 100,
+            });
+            // Only return runners we haven't already seen at org level
+            return runnerData.runners
+              .filter((r) => !orgRunnerIds.has(r.id))
+              .map((runner) =>
+                normalizeRunner(runner, { scope: 'repo', owner: repo.owner.login, repo: repo.name })
+              );
+          })
+        );
+
+        for (const result of repoResults) {
+          if (result.status === 'fulfilled') {
+            runners.push(...result.value);
+          }
+          // Silently skip 403/404 (most repos won't have repo-level runners)
+        }
+      }
+    } catch (err) {
+      console.error(
+        `runnerService: failed to list repos for ${account.login}:`,
+        err.message
+      );
+    }
   } else {
     // User-level: fetch repo-level runners
     try {

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -1,11 +1,11 @@
 import { getGitHubClient } from '../utils/githubAuth.js';
 import WorkflowRun from '../models/WorkflowRun.js';
 
-// In-memory cache with 5-minute TTL
+// In-memory cache with 2-minute TTL
 const cache = {
   data: null,
   fetchedAt: null,
-  TTL_MS: 5 * 60 * 1000,
+  TTL_MS: 2 * 60 * 1000,
 };
 
 const isCacheValid = () =>
@@ -83,8 +83,10 @@ const fetchInstallationRunners = async (installation) => {
   if (account.type === 'Organization') {
     try {
       // Fetch all runners AND runner groups in parallel
+      // Use raw request for runners to ensure busy flag is included
+      // (Octokit v19 convenience method may strip it)
       const [runnersResult, groupMapResult] = await Promise.allSettled([
-        client.rest.actions.listSelfHostedRunnersForOrg({
+        client.request('GET /orgs/{org}/actions/runners', {
           org: account.login,
           per_page: 100,
         }),
@@ -94,7 +96,13 @@ const fetchInstallationRunners = async (installation) => {
       const groupMap = groupMapResult.status === 'fulfilled' ? groupMapResult.value : new Map();
 
       if (runnersResult.status === 'fulfilled') {
-        for (const runner of runnersResult.value.data.runners) {
+        const runnersData = runnersResult.value.data.runners;
+        // Log first runner to debug busy flag
+        if (runnersData.length > 0) {
+          const sample = runnersData[0];
+          console.log(`runnerService: sample runner for ${account.login}: name=${sample.name}, status=${sample.status}, busy=${sample.busy}, runner_group_id=${sample.runner_group_id}`);
+        }
+        for (const runner of runnersData) {
           // Look up group name from the groupMap using runner_group_id
           let groupName = null;
           if (runner.runner_group_id && groupMap.size > 0) {

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -1,19 +1,24 @@
 import { getGitHubClient } from '../utils/githubAuth.js';
 import WorkflowRun from '../models/WorkflowRun.js';
 
-// In-memory cache with 60-second TTL
+// In-memory cache with 5-minute TTL
 const cache = {
   data: null,
   fetchedAt: null,
-  TTL_MS: 60 * 1000,
+  TTL_MS: 5 * 60 * 1000,
 };
 
 const isCacheValid = () =>
   cache.data !== null && cache.fetchedAt !== null && Date.now() - cache.fetchedAt < cache.TTL_MS;
 
 /**
- * Fetch all self-hosted runners across all installations (org + repo level).
- * Results are cached for 60 seconds to avoid hammering the GitHub API.
+ * Fetch all self-hosted runners across all installations.
+ * Org-level runners are fetched per runner group for accurate group names.
+ * Repo-level runner fetching is skipped for org installations (org runners
+ * are already visible to all repos, and repo-level calls mostly return 403).
+ * Results are cached for 5 minutes.
+ *
+ * All org fetches run in parallel for speed.
  *
  * @returns {Promise<Array>} Flat array of runner objects
  */
@@ -22,122 +27,18 @@ export const getAllRunners = async () => {
     return cache.data;
   }
 
+  const startTime = Date.now();
   const { app, installations } = await getGitHubClient();
+
+  // Process all installations in parallel
+  const results = await Promise.allSettled(
+    installations.map((installation) => fetchInstallationRunners(installation))
+  );
+
   const runners = [];
-
-  for (const installation of installations) {
-    let client;
-    try {
-      const result = await getGitHubClient(installation.id);
-      client = result.app;
-    } catch (err) {
-      console.error(
-        `runnerService: failed to get client for installation ${installation.id}:`,
-        err.message
-      );
-      continue;
-    }
-
-    const account = installation.account;
-
-    // Org-level runners
-    if (account.type === 'Organization') {
-      try {
-        // Strategy: fetch runner groups, then fetch runners per group.
-        // This gives us accurate group names without relying on runner_group_id
-        // in the runner object (which some Octokit/API versions may not return).
-        const groupMap = await fetchRunnerGroupMap(client, account.login);
-
-        if (groupMap.size > 0) {
-          // Fetch runners per group for accurate group assignment
-          for (const [groupId, groupName] of groupMap) {
-            try {
-              const { data } = await client.request('GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners', {
-                org: account.login,
-                runner_group_id: groupId,
-                per_page: 100,
-              });
-              for (const runner of data.runners) {
-                runners.push(normalizeRunner(runner, {
-                  scope: 'org',
-                  owner: account.login,
-                  groupName,
-                }));
-              }
-            } catch (err) {
-              console.error(
-                `runnerService: failed to list runners for group ${groupName} (${groupId}) in ${account.login}:`,
-                err.message
-              );
-            }
-          }
-        } else {
-          // Fallback: fetch all runners if group fetch failed
-          const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
-            org: account.login,
-            per_page: 100,
-          });
-          for (const runner of data.runners) {
-            runners.push(normalizeRunner(runner, {
-              scope: 'org',
-              owner: account.login,
-            }));
-          }
-        }
-      } catch (err) {
-        console.error(
-          `runnerService: failed to list org runners for ${account.login}:`,
-          err.message
-        );
-      }
-    }
-
-    // Repo-level runners — list repos for this installation then fetch runners per repo
-    try {
-      let page = 1;
-      while (true) {
-        const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({
-          per_page: 100,
-          page,
-        });
-        if (!reposData.repositories || reposData.repositories.length === 0) break;
-
-        for (const repo of reposData.repositories) {
-          try {
-            const { data: runnerData } =
-              await client.rest.actions.listSelfHostedRunnersForRepo({
-                owner: repo.owner.login,
-                repo: repo.name,
-                per_page: 100,
-              });
-            for (const runner of runnerData.runners) {
-              runners.push(
-                normalizeRunner(runner, {
-                  scope: 'repo',
-                  owner: repo.owner.login,
-                  repo: repo.name,
-                })
-              );
-            }
-          } catch (err) {
-            // Skip repos where the app lacks runner read permission
-            if (err.status !== 403 && err.status !== 404) {
-              console.error(
-                `runnerService: failed to list repo runners for ${repo.full_name}:`,
-                err.message
-              );
-            }
-          }
-        }
-
-        if (reposData.repositories.length < 100) break;
-        page++;
-      }
-    } catch (err) {
-      console.error(
-        `runnerService: failed to list repos for installation ${installation.id}:`,
-        err.message
-      );
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      runners.push(...result.value);
     }
   }
 
@@ -151,8 +52,112 @@ export const getAllRunners = async () => {
 
   cache.data = unique;
   cache.fetchedAt = Date.now();
+  console.log(`runnerService: fetched ${unique.length} runners from ${installations.length} installations in ${Date.now() - startTime}ms`);
 
   return unique;
+};
+
+/**
+ * Fetch runners for a single installation.
+ * For orgs: fetch runner groups, then runners per group (skips repo-level).
+ * For user accounts: fetch repo-level runners.
+ */
+const fetchInstallationRunners = async (installation) => {
+  const runners = [];
+  let client;
+
+  try {
+    const result = await getGitHubClient(installation.id);
+    client = result.app;
+  } catch (err) {
+    console.error(
+      `runnerService: failed to get client for installation ${installation.id}:`,
+      err.message
+    );
+    return runners;
+  }
+
+  const account = installation.account;
+
+  if (account.type === 'Organization') {
+    // Org-level: fetch runner groups, then runners per group
+    try {
+      const groupMap = await fetchRunnerGroupMap(client, account.login);
+
+      if (groupMap.size > 0) {
+        // Fetch runners per group in parallel
+        const groupResults = await Promise.allSettled(
+          [...groupMap.entries()].map(async ([groupId, groupName]) => {
+            const { data } = await client.request('GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners', {
+              org: account.login,
+              runner_group_id: groupId,
+              per_page: 100,
+            });
+            return data.runners.map((runner) =>
+              normalizeRunner(runner, { scope: 'org', owner: account.login, groupName })
+            );
+          })
+        );
+
+        for (const result of groupResults) {
+          if (result.status === 'fulfilled') {
+            runners.push(...result.value);
+          }
+        }
+      } else {
+        // Fallback: fetch all runners if group fetch failed
+        const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
+          org: account.login,
+          per_page: 100,
+        });
+        for (const runner of data.runners) {
+          runners.push(normalizeRunner(runner, { scope: 'org', owner: account.login }));
+        }
+      }
+    } catch (err) {
+      console.error(
+        `runnerService: failed to list org runners for ${account.login}:`,
+        err.message
+      );
+    }
+    // Skip repo-level fetching for orgs — org runners are already visible
+    // to all repos, and repo-level calls mostly return 403.
+  } else {
+    // User-level: fetch repo-level runners
+    try {
+      const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({
+        per_page: 100,
+      });
+
+      if (reposData.repositories && reposData.repositories.length > 0) {
+        const repoResults = await Promise.allSettled(
+          reposData.repositories.map(async (repo) => {
+            const { data: runnerData } = await client.rest.actions.listSelfHostedRunnersForRepo({
+              owner: repo.owner.login,
+              repo: repo.name,
+              per_page: 100,
+            });
+            return runnerData.runners.map((runner) =>
+              normalizeRunner(runner, { scope: 'repo', owner: repo.owner.login, repo: repo.name })
+            );
+          })
+        );
+
+        for (const result of repoResults) {
+          if (result.status === 'fulfilled') {
+            runners.push(...result.value);
+          }
+        }
+      }
+    } catch (err) {
+      console.error(
+        `runnerService: failed to list repos for installation ${installation.id}:`,
+        err.message
+      );
+    }
+  }
+
+  return runners;
 };
 
 /**

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -167,19 +167,27 @@ const fetchInstallationRunners = async (installation) => {
               per_page: 100,
             });
             // Only return runners we haven't already seen at org level
-            return runnerData.runners
-              .filter((r) => !orgRunnerIds.has(r.id))
-              .map((runner) =>
-                normalizeRunner(runner, { scope: 'repo', owner: repo.owner.login, repo: repo.name })
-              );
+            const newRunners = runnerData.runners
+              .filter((r) => !orgRunnerIds.has(r.id));
+            if (newRunners.length > 0) {
+              console.log(`runnerService: found ${newRunners.length} repo-level runner(s) in ${repo.full_name}`);
+            }
+            return newRunners.map((runner) =>
+              normalizeRunner(runner, { scope: 'repo', owner: repo.owner.login, repo: repo.name })
+            );
           })
         );
 
+        let repoRunnerCount = 0;
         for (const result of repoResults) {
           if (result.status === 'fulfilled') {
             runners.push(...result.value);
+            repoRunnerCount += result.value.length;
           }
           // Silently skip 403/404 (most repos won't have repo-level runners)
+        }
+        if (repoRunnerCount > 0) {
+          console.log(`runnerService: added ${repoRunnerCount} repo-level runner(s) for ${account.login}`);
         }
       }
     } catch (err) {

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -1,0 +1,169 @@
+import { getGitHubClient } from '../utils/githubAuth.js';
+
+// In-memory cache with 60-second TTL
+const cache = {
+  data: null,
+  fetchedAt: null,
+  TTL_MS: 60 * 1000,
+};
+
+const isCacheValid = () =>
+  cache.data !== null && cache.fetchedAt !== null && Date.now() - cache.fetchedAt < cache.TTL_MS;
+
+/**
+ * Fetch all self-hosted runners across all installations (org + repo level).
+ * Results are cached for 60 seconds to avoid hammering the GitHub API.
+ *
+ * @returns {Promise<Array>} Flat array of runner objects
+ */
+export const getAllRunners = async () => {
+  if (isCacheValid()) {
+    return cache.data;
+  }
+
+  const { app, installations } = await getGitHubClient();
+  const runners = [];
+
+  for (const installation of installations) {
+    let client;
+    try {
+      const result = await getGitHubClient(installation.id);
+      client = result.app;
+    } catch (err) {
+      console.error(
+        `runnerService: failed to get client for installation ${installation.id}:`,
+        err.message
+      );
+      continue;
+    }
+
+    const account = installation.account;
+
+    // Org-level runners
+    if (account.type === 'Organization') {
+      try {
+        const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
+          org: account.login,
+          per_page: 100,
+        });
+        for (const runner of data.runners) {
+          runners.push(normalizeRunner(runner, { scope: 'org', owner: account.login }));
+        }
+      } catch (err) {
+        console.error(
+          `runnerService: failed to list org runners for ${account.login}:`,
+          err.message
+        );
+      }
+    }
+
+    // Repo-level runners — list repos for this installation then fetch runners per repo
+    try {
+      let page = 1;
+      while (true) {
+        const { data: reposData } = await client.rest.apps.listReposAccessibleToInstallation({
+          per_page: 100,
+          page,
+        });
+        if (!reposData.repositories || reposData.repositories.length === 0) break;
+
+        for (const repo of reposData.repositories) {
+          try {
+            const { data: runnerData } =
+              await client.rest.actions.listSelfHostedRunnersForRepo({
+                owner: repo.owner.login,
+                repo: repo.name,
+                per_page: 100,
+              });
+            for (const runner of runnerData.runners) {
+              runners.push(
+                normalizeRunner(runner, {
+                  scope: 'repo',
+                  owner: repo.owner.login,
+                  repo: repo.name,
+                })
+              );
+            }
+          } catch (err) {
+            // Skip repos where the app lacks runner read permission
+            if (err.status !== 403 && err.status !== 404) {
+              console.error(
+                `runnerService: failed to list repo runners for ${repo.full_name}:`,
+                err.message
+              );
+            }
+          }
+        }
+
+        if (reposData.repositories.length < 100) break;
+        page++;
+      }
+    } catch (err) {
+      console.error(
+        `runnerService: failed to list repos for installation ${installation.id}:`,
+        err.message
+      );
+    }
+  }
+
+  // Deduplicate by runner id (a runner may appear at both org and repo scope)
+  const seen = new Set();
+  const unique = runners.filter((r) => {
+    if (seen.has(r.id)) return false;
+    seen.add(r.id);
+    return true;
+  });
+
+  cache.data = unique;
+  cache.fetchedAt = Date.now();
+
+  return unique;
+};
+
+/**
+ * Get a single runner by its numeric GitHub runner ID.
+ *
+ * @param {number|string} runnerId
+ * @returns {Promise<Object|null>}
+ */
+export const getRunnerById = async (runnerId) => {
+  const runners = await getAllRunners();
+  const id = Number(runnerId);
+  return runners.find((r) => r.id === id) ?? null;
+};
+
+/**
+ * Invalidate the in-memory cache (useful after a status update event).
+ */
+export const invalidateCache = () => {
+  cache.data = null;
+  cache.fetchedAt = null;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Normalise a raw GitHub runner object into the shape our API returns.
+ */
+const normalizeRunner = (runner, context) => ({
+  id: runner.id,
+  name: runner.name,
+  // GitHub reports "online" / "offline"; busy is derived from busy flag
+  status: deriveStatus(runner),
+  os: runner.os ?? null,
+  labels: (runner.labels ?? []).map((l) => l.name),
+  runnerGroup: runner.runner_group_name ?? null,
+  busy: runner.busy ?? false,
+  scope: context.scope,
+  owner: context.owner,
+  repo: context.repo ?? null,
+});
+
+/**
+ * Map GitHub's status + busy flag to one of: online | busy | idle | offline
+ */
+const deriveStatus = (runner) => {
+  if (runner.status === 'offline') return 'offline';
+  if (runner.busy) return 'busy';
+  return 'idle';
+};

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -42,12 +42,19 @@ export const getAllRunners = async () => {
     // Org-level runners
     if (account.type === 'Organization') {
       try {
+        // Fetch runner groups first to map group IDs to names
+        const groupMap = await fetchRunnerGroupMap(client, account.login);
+
         const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
           org: account.login,
           per_page: 100,
         });
         for (const runner of data.runners) {
-          runners.push(normalizeRunner(runner, { scope: 'org', owner: account.login }));
+          runners.push(normalizeRunner(runner, {
+            scope: 'org',
+            owner: account.login,
+            groupMap,
+          }));
         }
       } catch (err) {
         console.error(
@@ -143,21 +150,53 @@ export const invalidateCache = () => {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
+ * Fetch org-level runner groups and return a Map of groupId → groupName.
+ * Gracefully returns an empty map if the API call fails (e.g. missing permission).
+ */
+const fetchRunnerGroupMap = async (client, org) => {
+  const map = new Map();
+  try {
+    const { data } = await client.rest.actions.listSelfHostedRunnerGroupsForOrg({
+      org,
+      per_page: 100,
+    });
+    for (const group of data.runner_groups) {
+      map.set(group.id, group.name);
+    }
+  } catch (err) {
+    console.error(`runnerService: failed to fetch runner groups for ${org}:`, err.message);
+  }
+  return map;
+};
+
+/**
  * Normalise a raw GitHub runner object into the shape our API returns.
  */
-const normalizeRunner = (runner, context) => ({
-  id: runner.id,
-  name: runner.name,
-  // GitHub reports "online" / "offline"; busy is derived from busy flag
-  status: deriveStatus(runner),
-  os: runner.os ?? null,
-  labels: (runner.labels ?? []).map((l) => l.name),
-  runnerGroup: runner.runner_group_name ?? null,
-  busy: runner.busy ?? false,
-  scope: context.scope,
-  owner: context.owner,
-  repo: context.repo ?? null,
-});
+const normalizeRunner = (runner, context) => {
+  // Resolve runner group name: use the groupMap (from org-level fetch) if available,
+  // fall back to runner_group_name if the API ever includes it.
+  let groupName = null;
+  if (context.groupMap && runner.runner_group_id) {
+    groupName = context.groupMap.get(runner.runner_group_id) ?? null;
+  }
+  if (!groupName && runner.runner_group_name) {
+    groupName = runner.runner_group_name;
+  }
+
+  return {
+    id: runner.id,
+    name: runner.name,
+    status: deriveStatus(runner),
+    os: runner.os ?? null,
+    labels: (runner.labels ?? []).map((l) => l.name),
+    runnerGroup: groupName,
+    runnerGroupId: runner.runner_group_id ?? null,
+    busy: runner.busy ?? false,
+    scope: context.scope,
+    owner: context.owner,
+    repo: context.repo ?? null,
+  };
+};
 
 /**
  * Map GitHub's status + busy flag to one of: online | busy | idle | offline

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -188,6 +188,16 @@ export const invalidateCache = () => {
 };
 
 /**
+ * Get cache metadata (TTL, age, whether valid).
+ */
+export const getCacheInfo = () => ({
+  ttlMs: cache.TTL_MS,
+  cachedAt: cache.fetchedAt ? new Date(cache.fetchedAt).toISOString() : null,
+  ageMs: cache.fetchedAt ? Date.now() - cache.fetchedAt : null,
+  valid: isCacheValid(),
+});
+
+/**
  * Enrich runners with active workflow/job info from the RunWatch database.
  * For busy runners, find the in-progress workflow run whose jobs match the runner name.
  */

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -82,10 +82,12 @@ const fetchInstallationRunners = async (installation) => {
 
   if (account.type === 'Organization') {
     try {
-      // Fetch all runners AND runner groups in parallel
-      // Use raw request for runners to ensure busy flag is included
-      // (Octokit v19 convenience method may strip it)
-      const [runnersResult, groupMapResult] = await Promise.allSettled([
+      // Two-phase approach:
+      // 1. Fetch all runners (raw API) to get accurate busy status
+      // 2. Fetch runners per group to get accurate group names
+      // Then merge: use group names from phase 2, busy status from phase 1
+
+      const [allRunnersResult, groupMapResult] = await Promise.allSettled([
         client.request('GET /orgs/{org}/actions/runners', {
           org: account.login,
           per_page: 100,
@@ -95,31 +97,49 @@ const fetchInstallationRunners = async (installation) => {
 
       const groupMap = groupMapResult.status === 'fulfilled' ? groupMapResult.value : new Map();
 
-      if (runnersResult.status === 'fulfilled') {
-        const runnersData = runnersResult.value.data.runners;
-        // Log first runner to debug busy flag
-        if (runnersData.length > 0) {
-          const sample = runnersData[0];
-          console.log(`runnerService: sample runner for ${account.login}: name=${sample.name}, status=${sample.status}, busy=${sample.busy}, runner_group_id=${sample.runner_group_id}`);
-        }
-        for (const runner of runnersData) {
-          // Look up group name from the groupMap using runner_group_id
-          let groupName = null;
-          if (runner.runner_group_id && groupMap.size > 0) {
-            groupName = groupMap.get(runner.runner_group_id) ?? null;
+      // Build a busy status map from the all-runners response
+      const busyMap = new Map();
+      if (allRunnersResult.status === 'fulfilled') {
+        for (const runner of allRunnersResult.value.data.runners) {
+          busyMap.set(runner.id, runner.busy ?? false);
+          // Debug log for first runner
+          if (busyMap.size === 1) {
+            console.log(`runnerService: sample runner for ${account.login}: name=${runner.name}, status=${runner.status}, busy=${runner.busy}, runner_group_id=${runner.runner_group_id}`);
           }
-
-          runners.push(normalizeRunner(runner, {
-            scope: 'org',
-            owner: account.login,
-            groupName,
-          }));
         }
-      } else {
-        console.error(
-          `runnerService: failed to list org runners for ${account.login}:`,
-          runnersResult.reason?.message
+      }
+
+      if (groupMap.size > 0) {
+        // Fetch runners per group in parallel for accurate group assignment
+        const groupResults = await Promise.allSettled(
+          [...groupMap.entries()].map(async ([groupId, groupName]) => {
+            const { data } = await client.request('GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners', {
+              org: account.login,
+              runner_group_id: groupId,
+              per_page: 100,
+            });
+            return data.runners.map((runner) => {
+              // Override busy from the all-runners response (more reliable)
+              const busy = busyMap.has(runner.id) ? busyMap.get(runner.id) : (runner.busy ?? false);
+              return normalizeRunner({ ...runner, busy }, {
+                scope: 'org',
+                owner: account.login,
+                groupName,
+              });
+            });
+          })
         );
+
+        for (const result of groupResults) {
+          if (result.status === 'fulfilled') {
+            runners.push(...result.value);
+          }
+        }
+      } else if (allRunnersResult.status === 'fulfilled') {
+        // Fallback: use all-runners response if groups couldn't be fetched
+        for (const runner of allRunnersResult.value.data.runners) {
+          runners.push(normalizeRunner(runner, { scope: 'org', owner: account.login }));
+        }
       }
     } catch (err) {
       console.error(

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -42,19 +42,46 @@ export const getAllRunners = async () => {
     // Org-level runners
     if (account.type === 'Organization') {
       try {
-        // Fetch runner groups first to map group IDs to names
+        // Strategy: fetch runner groups, then fetch runners per group.
+        // This gives us accurate group names without relying on runner_group_id
+        // in the runner object (which some Octokit/API versions may not return).
         const groupMap = await fetchRunnerGroupMap(client, account.login);
 
-        const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
-          org: account.login,
-          per_page: 100,
-        });
-        for (const runner of data.runners) {
-          runners.push(normalizeRunner(runner, {
-            scope: 'org',
-            owner: account.login,
-            groupMap,
-          }));
+        if (groupMap.size > 0) {
+          // Fetch runners per group for accurate group assignment
+          for (const [groupId, groupName] of groupMap) {
+            try {
+              const { data } = await client.rest.actions.listSelfHostedRunnersInGroupForOrg({
+                org: account.login,
+                runner_group_id: groupId,
+                per_page: 100,
+              });
+              for (const runner of data.runners) {
+                runners.push(normalizeRunner(runner, {
+                  scope: 'org',
+                  owner: account.login,
+                  groupName,
+                }));
+              }
+            } catch (err) {
+              console.error(
+                `runnerService: failed to list runners for group ${groupName} (${groupId}) in ${account.login}:`,
+                err.message
+              );
+            }
+          }
+        } else {
+          // Fallback: fetch all runners if group fetch failed
+          const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
+            org: account.login,
+            per_page: 100,
+          });
+          for (const runner of data.runners) {
+            runners.push(normalizeRunner(runner, {
+              scope: 'org',
+              owner: account.login,
+            }));
+          }
         }
       } catch (err) {
         console.error(
@@ -173,10 +200,12 @@ const fetchRunnerGroupMap = async (client, org) => {
  * Normalise a raw GitHub runner object into the shape our API returns.
  */
 const normalizeRunner = (runner, context) => {
-  // Resolve runner group name: use the groupMap (from org-level fetch) if available,
-  // fall back to runner_group_name if the API ever includes it.
-  let groupName = null;
-  if (context.groupMap && runner.runner_group_id) {
+  // Group name priority:
+  // 1. Explicit groupName from context (from per-group fetch)
+  // 2. Lookup via groupMap + runner_group_id (legacy path)
+  // 3. runner_group_name if API returns it directly
+  let groupName = context.groupName ?? null;
+  if (!groupName && context.groupMap && runner.runner_group_id) {
     groupName = context.groupMap.get(runner.runner_group_id) ?? null;
   }
   if (!groupName && runner.runner_group_name) {

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -59,7 +59,8 @@ export const getAllRunners = async () => {
 
 /**
  * Fetch runners for a single installation.
- * For orgs: fetch runner groups, then runners per group (skips repo-level).
+ * For orgs: fetch all runners (with busy status), then fetch runner groups
+ * to map group IDs to names, and merge the info.
  * For user accounts: fetch repo-level runners.
  */
 const fetchInstallationRunners = async (installation) => {
@@ -80,39 +81,37 @@ const fetchInstallationRunners = async (installation) => {
   const account = installation.account;
 
   if (account.type === 'Organization') {
-    // Org-level: fetch runner groups, then runners per group
     try {
-      const groupMap = await fetchRunnerGroupMap(client, account.login);
-
-      if (groupMap.size > 0) {
-        // Fetch runners per group in parallel
-        const groupResults = await Promise.allSettled(
-          [...groupMap.entries()].map(async ([groupId, groupName]) => {
-            const { data } = await client.request('GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners', {
-              org: account.login,
-              runner_group_id: groupId,
-              per_page: 100,
-            });
-            return data.runners.map((runner) =>
-              normalizeRunner(runner, { scope: 'org', owner: account.login, groupName })
-            );
-          })
-        );
-
-        for (const result of groupResults) {
-          if (result.status === 'fulfilled') {
-            runners.push(...result.value);
-          }
-        }
-      } else {
-        // Fallback: fetch all runners if group fetch failed
-        const { data } = await client.rest.actions.listSelfHostedRunnersForOrg({
+      // Fetch all runners AND runner groups in parallel
+      const [runnersResult, groupMapResult] = await Promise.allSettled([
+        client.rest.actions.listSelfHostedRunnersForOrg({
           org: account.login,
           per_page: 100,
-        });
-        for (const runner of data.runners) {
-          runners.push(normalizeRunner(runner, { scope: 'org', owner: account.login }));
+        }),
+        fetchRunnerGroupMap(client, account.login),
+      ]);
+
+      const groupMap = groupMapResult.status === 'fulfilled' ? groupMapResult.value : new Map();
+
+      if (runnersResult.status === 'fulfilled') {
+        for (const runner of runnersResult.value.data.runners) {
+          // Look up group name from the groupMap using runner_group_id
+          let groupName = null;
+          if (runner.runner_group_id && groupMap.size > 0) {
+            groupName = groupMap.get(runner.runner_group_id) ?? null;
+          }
+
+          runners.push(normalizeRunner(runner, {
+            scope: 'org',
+            owner: account.login,
+            groupName,
+          }));
         }
+      } else {
+        console.error(
+          `runnerService: failed to list org runners for ${account.login}:`,
+          runnersResult.reason?.message
+        );
       }
     } catch (err) {
       console.error(

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -156,8 +156,11 @@ const fetchInstallationRunners = async (installation) => {
       });
 
       if (reposData.repositories && reposData.repositories.length > 0) {
-        // Track org runner IDs to avoid duplicates
-        const orgRunnerIds = new Set(runners.map((r) => r.id));
+        // Track org runner IDs to avoid true duplicates
+        // Use composite key (id + scope + repo) since the same physical
+        // machine can be registered as both an org runner and a repo runner
+        // with different names/configs (same runner ID)
+        const orgRunnerKeys = new Set(runners.map((r) => `${r.id}:${r.scope}:${r.repo || ''}`));
 
         const repoResults = await Promise.allSettled(
           reposData.repositories.map(async (repo) => {
@@ -166,9 +169,9 @@ const fetchInstallationRunners = async (installation) => {
               repo: repo.name,
               per_page: 100,
             });
-            // Only return runners we haven't already seen at org level
+            // Only return runners we haven't already seen with the same scope
             const newRunners = runnerData.runners
-              .filter((r) => !orgRunnerIds.has(r.id));
+              .filter((r) => !orgRunnerKeys.has(`${r.id}:repo:${repo.name}`));
             if (newRunners.length > 0) {
               console.log(`runnerService: found ${newRunners.length} repo-level runner(s) in ${repo.full_name}`);
             }

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -51,7 +51,7 @@ export const getAllRunners = async () => {
           // Fetch runners per group for accurate group assignment
           for (const [groupId, groupName] of groupMap) {
             try {
-              const { data } = await client.rest.actions.listSelfHostedRunnersInGroupForOrg({
+              const { data } = await client.request('GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners', {
                 org: account.login,
                 runner_group_id: groupId,
                 per_page: 100,
@@ -178,20 +178,23 @@ export const invalidateCache = () => {
 
 /**
  * Fetch org-level runner groups and return a Map of groupId → groupName.
- * Gracefully returns an empty map if the API call fails (e.g. missing permission).
+ * Uses a raw API request to avoid Octokit version issues with the
+ * listSelfHostedRunnerGroupsForOrg convenience method.
+ * Gracefully returns an empty map if the API call fails.
  */
 const fetchRunnerGroupMap = async (client, org) => {
   const map = new Map();
   try {
-    const { data } = await client.rest.actions.listSelfHostedRunnerGroupsForOrg({
+    const { data } = await client.request('GET /orgs/{org}/actions/runner-groups', {
       org,
       per_page: 100,
     });
     for (const group of data.runner_groups) {
       map.set(group.id, group.name);
     }
+    console.log(`runnerService: fetched ${map.size} runner groups for ${org}`);
   } catch (err) {
-    console.error(`runnerService: failed to fetch runner groups for ${org}:`, err.message);
+    console.error(`runnerService: failed to fetch runner groups for ${org}: status=${err.status}, message=${err.message}`);
   }
   return map;
 };

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -42,11 +42,13 @@ export const getAllRunners = async () => {
     }
   }
 
-  // Deduplicate by runner id (a runner may appear at both org and repo scope)
+  // Deduplicate by composite key (id + scope + repo) to allow the same
+  // physical runner to appear at both org and repo scope
   const seen = new Set();
   const unique = runners.filter((r) => {
-    if (seen.has(r.id)) return false;
-    seen.add(r.id);
+    const key = `${r.id}:${r.scope}:${r.repo || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
     return true;
   });
 

--- a/server/src/services/runnerService.js
+++ b/server/src/services/runnerService.js
@@ -1,4 +1,5 @@
 import { getGitHubClient } from '../utils/githubAuth.js';
+import WorkflowRun from '../models/WorkflowRun.js';
 
 // In-memory cache with 60-second TTL
 const cache = {
@@ -172,6 +173,76 @@ export const getRunnerById = async (runnerId) => {
 export const invalidateCache = () => {
   cache.data = null;
   cache.fetchedAt = null;
+};
+
+/**
+ * Enrich runners with active workflow/job info from the RunWatch database.
+ * For busy runners, find the in-progress workflow run whose jobs match the runner name.
+ */
+export const enrichRunnersWithActiveJobs = async (runners) => {
+  const busyRunners = runners.filter((r) => r.status === 'busy');
+  if (busyRunners.length === 0) return runners;
+
+  const busyNames = busyRunners.map((r) => r.name);
+
+  try {
+    // Find in-progress workflow runs that have jobs assigned to these runners
+    const activeRuns = await WorkflowRun.find({
+      'run.status': 'in_progress',
+      'jobs.runner_name': { $in: busyNames },
+    }).lean();
+
+    // Build a map: runner_name → { workflow info, job info, links }
+    const runnerJobMap = new Map();
+    for (const run of activeRuns) {
+      if (!run.jobs) continue;
+      for (const job of run.jobs) {
+        if (job.runner_name && busyNames.includes(job.runner_name) && job.status === 'in_progress') {
+          runnerJobMap.set(job.runner_name, {
+            workflowName: run.workflow?.name ?? null,
+            workflowRunId: run.run?.id ?? null,
+            workflowRunUrl: run.run?.url ?? null,
+            jobName: job.name ?? null,
+            repository: run.repository?.fullName ?? null,
+          });
+        }
+      }
+    }
+
+    // Also check runner_name at the run level (for runs without job details)
+    if (runnerJobMap.size < busyRunners.length) {
+      const remainingNames = busyNames.filter((n) => !runnerJobMap.has(n));
+      if (remainingNames.length > 0) {
+        const runLevelMatches = await WorkflowRun.find({
+          'run.status': 'in_progress',
+          'run.runner_name': { $in: remainingNames },
+        }).lean();
+
+        for (const run of runLevelMatches) {
+          if (run.run?.runner_name && remainingNames.includes(run.run.runner_name)) {
+            runnerJobMap.set(run.run.runner_name, {
+              workflowName: run.workflow?.name ?? null,
+              workflowRunId: run.run?.id ?? null,
+              workflowRunUrl: run.run?.url ?? null,
+              jobName: null,
+              repository: run.repository?.fullName ?? null,
+            });
+          }
+        }
+      }
+    }
+
+    // Attach active job info to runners
+    return runners.map((r) => {
+      if (r.status === 'busy' && runnerJobMap.has(r.name)) {
+        return { ...r, activeJob: runnerJobMap.get(r.name) };
+      }
+      return r;
+    });
+  } catch (err) {
+    console.error('runnerService: failed to enrich runners with active jobs:', err.message);
+    return runners;
+  }
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements **Issue #19** — adds a dedicated tab/view for monitoring self-hosted GitHub Actions runners.

### Changes

#### Nav Updates
- Renamed **Dashboard** → **Workflows** in the left sidebar
- Added new **Runners** tab with `precision_manufacturing` icon

#### Backend (3 files)
- **`server/src/services/runnerService.js`** (new) — Fetches self-hosted runners across all GitHub App installations (org + repo level), deduplicates by runner ID, caches results for 60 seconds
- **`server/src/controllers/runnerController.js`** (new) — `GET /runners` with optional filters (status, label, group) + summary stats; `GET /runners/:runnerId` with numeric ID validation
- **`server/src/routes/api.js`** (updated) — Added runner routes

#### Frontend (3 files)
- **`client/src/features/runners/RunnersView.jsx`** (new) — Full runner monitoring UI:
  - Summary stats bar (Total / Idle / Busy / Offline)
  - Search by runner name, filter by status and label
  - Runner cards showing name, OS, status indicator, scope, runner group, labels
  - Collapsible sections grouped by runner group
  - Auto-refresh every 30 seconds with manual refresh button
  - Loading/error states with retry
- **`client/src/App.js`** (updated) — Added `/runners` route
- **`client/src/api/apiService.js`** (updated) — Added `getRunners()` and `getRunnerById()`

#### WebSocket
- Added `runnerStatusUpdate` event documentation for future real-time updates

### Technical Notes
- Uses existing GitHub App auth (`getGitHubClient`) — requires **Self-hosted runners (read)** permission on the GitHub App
- Runner status derived from GitHub's `status` + `busy` flag → `idle` | `busy` | `offline`
- 60-second in-memory cache prevents API rate limit issues
- UI matches existing dark theme and Material Symbols icon set

### Screenshots
_Deploy to preview — the Runners tab appears in the left sidebar_

Closes #19