### PR TITLE
feat: support comma-separated CLIENT_URL for multiple CORS origins

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -47,7 +47,7 @@ if (isProduction && !process.env.CLIENT_URL) {
   throw new Error('CORS configuration error: CLIENT_URL must be set in production.');
 }
 const allowedOrigins = [
-  ...(process.env.CLIENT_URL ? [process.env.CLIENT_URL] : ['http://localhost']),
+  ...(process.env.CLIENT_URL ? process.env.CLIENT_URL.split(',').map(u => u.trim()) : ['http://localhost']),
   ...(!isProduction ? ['http://localhost:3000'] : [])
 ];
 app.use(cors({

--- a/server/src/middleware/socket.js
+++ b/server/src/middleware/socket.js
@@ -11,7 +11,7 @@ const setupSocket = (server) => {
   // Mirror the Express CORS allowlist: localhost:3000 only in non-production.
   // Originless connections (server-to-server / CLI clients) are allowed, matching Express CORS behaviour.
   const allowedOrigins = [
-    ...(process.env.CLIENT_URL ? [process.env.CLIENT_URL] : ['http://localhost']),
+    ...(process.env.CLIENT_URL ? process.env.CLIENT_URL.split(',').map(u => u.trim()) : ['http://localhost']),
     ...(!isProduction ? ['http://localhost:3000'] : [])
   ];
 


### PR DESCRIPTION
## Summary

Allows `CLIENT_URL` to accept multiple comma-separated origins:

```
CLIENT_URL=http://localhost,http://192.168.10.198
```

Both Express CORS and Socket.IO CORS now split and trim the value, enabling access from LAN IPs or multiple environments without code changes.

**Use case:** Testing RunWatch from a different machine on the local network (e.g. accessing `http://192.168.10.198` instead of `http://localhost`).