### PR TITLE
fix: filter job metrics to only count jobs from active workflow runs

### DIFF
--- a/server/src/services/workflowService.js
+++ b/server/src/services/workflowService.js
@@ -665,10 +665,15 @@ export const getJobMetrics = async () => {
     // console.log('Total active jobs:', totalActive);
     
     // Get all jobs grouped by organization
+    // Only count jobs from workflow runs that are still active — completed/cancelled
+    // workflows should not contribute to active job counts even if individual job
+    // status wasn't updated (e.g. missed webhook events).
     const jobsByOrg = await WorkflowRun.aggregate([
       {
         $match: {
-          'jobs': { $exists: true, $not: { $size: 0 } }
+          'jobs': { $exists: true, $not: { $size: 0 } },
+          'run.status': { $in: ['in_progress', 'queued', 'waiting', 'pending', 'requested'] },
+          'run.conclusion': null
         }
       },
       {


### PR DESCRIPTION
## Problem

The dashboard shows ghost job counts (e.g. **2 JOBS RUNNING**) even when no workflows are active. This happens when `workflow_job completed` webhook events are missed or arrive late — the job status remains `in_progress` in the database even after the parent workflow run has finished.

## Root Cause

`getJobMetrics()` queries all jobs with active statuses (`in_progress`, `queued`, etc.) without checking whether the parent workflow run is still active. Jobs from completed/cancelled workflows were being counted as active.

## Fix

Added `run.status` and `run.conclusion` filters to the `getJobMetrics()` aggregate pipeline so only jobs belonging to still-active workflow runs (`in_progress`, `queued`, `waiting`, `pending`, `requested` with no conclusion) are included in the count.

## Testing

1. Trigger some workflow runs and let them complete
2. Verify the Jobs Running/Queued badges show 0 when no workflows are active
3. Verify badges still show correct counts during active runs