### PR TITLE
fix: upgrade Node.js 18→20 in GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 


### PR DESCRIPTION
## Problem
The `Deploy Demo to GitHub Pages` workflow fails with:
```
ReferenceError: crypto is not defined
```
`serialize-javascript` (used by `css-minimizer-webpack-plugin`) calls `crypto.getRandomValues()` which requires the Web Crypto API on the global scope.

Node.js 18 does not expose `globalThis.crypto` by default (requires `--experimental-global-webcrypto`).

## Fix
Upgrade from Node.js 18 → 20 in the deploy-demo workflow. Node 20+ includes `globalThis.crypto` natively.

## Notes
- Node 18 reached EOL on 2025-04-30, so this also addresses the deprecation.
- GitHub Actions is deprecating Node 20 actions in June 2026 — this keeps us current.