### PR TITLE
fix(security): patch mongoose, express-rate-limit, ip-address vulnerabilities

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
-      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -1071,12 +1071,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1324,9 +1324,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1494,25 +1494,25 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
-      "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
-        "mongodb-connection-string-url": "^3.0.0"
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
         "node": ">=16.20.1"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.632.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
         "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "snappy": "^7.3.2",
         "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
@@ -1550,14 +1550,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.11.0.tgz",
-      "integrity": "sha512-xaQSuaLk2JKmXI5zDVVWXVCQTnWhAe8MFOijMnwOuP/wucKVphd3f+ouDKivCDMGjYBDrR7dtoyV0U093xbKqA==",
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.1.tgz",
+      "integrity": "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.10.1",
+        "bson": "^6.10.4",
         "kareem": "2.6.3",
-        "mongodb": "~6.13.0",
+        "mongodb": "~6.20.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -2313,12 +2313,12 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
-      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {


### PR DESCRIPTION
## Security Fixes (Automated Scan — 2026-05-11)

### Vulnerabilities Resolved

| Package | From | To | Severity | Advisory |
|---------|------|----|----------|----------|
| mongoose | ≤8.22.0 | 8.23.1 | **High** | [GHSA-wpg9-53fq-2r8h](https://github.com/advisories/GHSA-wpg9-53fq-2r8h) — Improper sanitization of $nor in sanitizeFilter allows NoSQL injection |
| ip-address | ≤10.1.0 | 10.2.0 | Moderate | [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) — XSS in Address6 HTML-emitting methods |
| express-rate-limit | 8.0.1–8.5.0 | 8.5.1 | Moderate | Depends on vulnerable ip-address |

### Changes
- `server/package-lock.json` updated via `npm audit fix` (non-breaking)

### Code Review
No new server-side code changes since last scan. All security-relevant files (server.js, socket.js, github.js, githubAuth.js, db.js, docker-compose.yml, .env.example) remain clean.